### PR TITLE
Handle transient empty rollout load errors during AI thread sync

### DIFF
--- a/crates/hunk-desktop/src/app/ai_runtime/core.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/core.rs
@@ -76,6 +76,8 @@ const NOTIFICATION_DRAIN_TIMEOUT: Duration = Duration::from_millis(2);
 const MAX_NOTIFICATIONS_PER_POLL: usize = 256;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const HOST_BOOTSTRAP_MAX_ATTEMPTS: usize = 12;
+const TRANSIENT_ROLLOUT_LOAD_MAX_RETRIES: usize = 3;
+const TRANSIENT_ROLLOUT_LOAD_RETRY_DELAY: Duration = Duration::from_millis(75);
 const LOOPBACK_PORT_RANGE_START: u16 = 49_152;
 const LOOPBACK_PORT_RANGE_SIZE: u16 = 16_384;
 static NEXT_LOOPBACK_PORT_OFFSET: AtomicU16 = AtomicU16::new(0);
@@ -774,21 +776,38 @@ impl AiWorkerRuntime {
         thread_id: String,
     ) -> Result<(), CodexIntegrationError> {
         let read_thread_id = thread_id.clone();
-        self.service.resume_thread(
-            &mut self.session,
-            ThreadResumeParams {
-                thread_id,
-                persist_extended_history: true,
-                ..ThreadResumeParams::default()
+        match retry_transient_rollout_load(
+            TRANSIENT_ROLLOUT_LOAD_MAX_RETRIES,
+            TRANSIENT_ROLLOUT_LOAD_RETRY_DELAY,
+            || {
+                self.service.resume_thread(
+                    &mut self.session,
+                    ThreadResumeParams {
+                        thread_id: thread_id.clone(),
+                        persist_extended_history: true,
+                        ..ThreadResumeParams::default()
+                    },
+                    self.request_timeout,
+                )?;
+                self.service.read_thread(
+                    &mut self.session,
+                    read_thread_id.clone(),
+                    true,
+                    self.request_timeout,
+                )?;
+                Ok(())
             },
-            self.request_timeout,
-        )?;
-        self.service.read_thread(
-            &mut self.session,
-            read_thread_id.clone(),
-            true,
-            self.request_timeout,
-        )?;
+        ) {
+            Ok(()) => {}
+            Err(error) if is_transient_rollout_load_error(&error) => {
+                tracing::debug!(
+                    thread_id = read_thread_id.as_str(),
+                    error = %error,
+                    "ignoring transient rollout load error while hydrating thread snapshot"
+                );
+            }
+            Err(error) => return Err(error),
+        }
         self.hydrate_thread_from_rollout_fallback_if_needed(read_thread_id.as_str());
         Ok(())
     }
@@ -797,8 +816,25 @@ impl AiWorkerRuntime {
         &mut self,
         thread_id: String,
     ) -> Result<(), CodexIntegrationError> {
-        self.service
-            .read_thread(&mut self.session, thread_id, false, self.request_timeout)?;
+        match retry_transient_rollout_load(
+            TRANSIENT_ROLLOUT_LOAD_MAX_RETRIES,
+            TRANSIENT_ROLLOUT_LOAD_RETRY_DELAY,
+            || {
+                self.service
+                    .read_thread(&mut self.session, thread_id.clone(), false, self.request_timeout)?;
+                Ok(())
+            },
+        ) {
+            Ok(()) => {}
+            Err(error) if is_transient_rollout_load_error(&error) => {
+                tracing::debug!(
+                    thread_id = thread_id.as_str(),
+                    error = %error,
+                    "ignoring transient rollout load error while refreshing thread metadata"
+                );
+            }
+            Err(error) => return Err(error),
+        }
         Ok(())
     }
 

--- a/crates/hunk-desktop/src/app/ai_runtime/helpers.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/helpers.rs
@@ -38,6 +38,44 @@ fn should_retry_stale_turn_after_steer_error(error: &CodexIntegrationError) -> b
         || normalized_message.contains("in progress turn")
 }
 
+fn is_transient_rollout_load_error(error: &CodexIntegrationError) -> bool {
+    let CodexIntegrationError::JsonRpcServerError { code, message } = error else {
+        return false;
+    };
+    if *code != -32603 {
+        return false;
+    }
+
+    let normalized_message = message.to_ascii_lowercase();
+    normalized_message.contains("failed to load rollout")
+        && normalized_message.contains("is empty")
+}
+
+fn retry_transient_rollout_load<T, F>(
+    max_retries: usize,
+    retry_delay: std::time::Duration,
+    mut operation: F,
+) -> Result<T, CodexIntegrationError>
+where
+    F: FnMut() -> Result<T, CodexIntegrationError>,
+{
+    let mut attempts = 0usize;
+    loop {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(error)
+                if is_transient_rollout_load_error(&error) && attempts < max_retries =>
+            {
+                attempts = attempts.saturating_add(1);
+                if !retry_delay.is_zero() {
+                    std::thread::sleep(retry_delay);
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 fn map_command_approval_decision(decision: AiApprovalDecision) -> CommandExecutionApprovalDecision {
     match decision {
         AiApprovalDecision::Accept => CommandExecutionApprovalDecision::Accept,

--- a/crates/hunk-desktop/src/app/ai_runtime/sync.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/sync.rs
@@ -45,28 +45,12 @@ impl AiWorkerRuntime {
                             .then_with(|| left.id.cmp(&right.id))
                     })
                     .map(|thread| thread.id.clone())
-            });
+        });
         let Some(thread_id) = thread_id else {
             return Ok(());
         };
 
-        self.service.resume_thread(
-            &mut self.session,
-            ThreadResumeParams {
-                thread_id: thread_id.clone(),
-                persist_extended_history: true,
-                ..ThreadResumeParams::default()
-            },
-            self.request_timeout,
-        )?;
-        self.service.read_thread(
-            &mut self.session,
-            thread_id.clone(),
-            true,
-            self.request_timeout,
-        )?;
-        self.hydrate_thread_from_rollout_fallback_if_needed(thread_id.as_str());
-        Ok(())
+        self.load_thread_snapshot(thread_id)
     }
 
     fn refresh_session_metadata(&mut self) -> Result<(), CodexIntegrationError> {

--- a/crates/hunk-desktop/src/app/ai_runtime/tests.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/tests.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod ai_tests {
+    use std::cell::Cell;
     use std::collections::HashMap;
     use std::sync::mpsc;
+    use std::time::Duration;
 
     use codex_app_server_protocol::AccountLoginCompletedNotification;
     use codex_app_server_protocol::AskForApproval;
@@ -31,11 +33,13 @@ mod ai_tests {
     use super::command_can_retry_after_reconnect;
     use super::dispatch_ai_worker_result;
     use super::reconnect_backoff;
+    use super::is_transient_rollout_load_error;
     use super::map_command_approval_decision;
     use super::map_file_change_approval_decision;
     use super::panic_payload_message;
     use super::preferred_rate_limit_snapshot;
     use super::request_id_key;
+    use super::retry_transient_rollout_load;
     use super::selected_ai_service_tier;
     use super::should_attempt_runtime_reconnect;
     use super::should_retry_stale_turn_after_steer_error;
@@ -265,6 +269,72 @@ mod ai_tests {
         assert!(!should_retry_stale_turn_after_steer_error(
             &CodexIntegrationError::WebSocketTransport("closed".to_string())
         ));
+    }
+
+    #[test]
+    fn transient_rollout_error_helper_matches_empty_rollout_server_errors_only() {
+        assert!(is_transient_rollout_load_error(
+            &CodexIntegrationError::JsonRpcServerError {
+                code: -32603,
+                message: "failed to load rollout '/tmp/rollout.jsonl' for thread thread-1: rollout at /tmp/rollout.jsonl is empty".to_string(),
+            }
+        ));
+        assert!(!is_transient_rollout_load_error(
+            &CodexIntegrationError::JsonRpcServerError {
+                code: -32603,
+                message: "failed to load rollout '/tmp/rollout.jsonl': permission denied"
+                    .to_string(),
+            }
+        ));
+        assert!(!is_transient_rollout_load_error(
+            &CodexIntegrationError::JsonRpcServerError {
+                code: -32602,
+                message: "failed to load rollout '/tmp/rollout.jsonl' for thread thread-1: rollout at /tmp/rollout.jsonl is empty".to_string(),
+            }
+        ));
+    }
+
+    #[test]
+    fn transient_rollout_retry_retries_until_success() {
+        let attempts = Cell::new(0usize);
+        let result = retry_transient_rollout_load(2, Duration::ZERO, || {
+            attempts.set(attempts.get().saturating_add(1));
+            if attempts.get() < 3 {
+                return Err(CodexIntegrationError::JsonRpcServerError {
+                    code: -32603,
+                    message:
+                        "failed to load rollout '/tmp/rollout.jsonl' for thread thread-1: rollout at /tmp/rollout.jsonl is empty"
+                            .to_string(),
+                });
+            }
+            Ok("loaded")
+        })
+        .expect("retry helper should succeed after transient rollout load errors");
+
+        assert_eq!(result, "loaded");
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[test]
+    fn transient_rollout_retry_does_not_retry_non_rollout_errors() {
+        let attempts = Cell::new(0usize);
+        let error = retry_transient_rollout_load(3, Duration::ZERO, || {
+            attempts.set(attempts.get().saturating_add(1));
+            Result::<(), CodexIntegrationError>::Err(CodexIntegrationError::JsonRpcServerError {
+                code: -32602,
+                message: "invalid params".to_string(),
+            })
+        })
+        .expect_err("non-rollout errors should not be retried");
+
+        assert_eq!(attempts.get(), 1);
+        match error {
+            CodexIntegrationError::JsonRpcServerError { code, message } => {
+                assert_eq!(code, -32602);
+                assert_eq!(message, "invalid params");
+            }
+            other => panic!("expected json-rpc error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/hunk-desktop/src/app/ai_thread_flow.rs
+++ b/crates/hunk-desktop/src/app/ai_thread_flow.rs
@@ -87,7 +87,10 @@ pub(super) fn ai_first_prompt_seed_for_thread(state: &AiState, thread_id: &str) 
         .filter(|prompt| !prompt.is_empty())
 }
 
-pub(super) fn ai_latest_agent_message_for_thread(state: &AiState, thread_id: &str) -> Option<String> {
+pub(super) fn ai_latest_agent_message_for_thread(
+    state: &AiState,
+    thread_id: &str,
+) -> Option<String> {
     state
         .items
         .values()
@@ -232,7 +235,10 @@ Changed files:\n{}\n\
 \n\
 Diff patch:\n{}\n",
         context.branch_name,
-        limit_text(context.prompt_seed.unwrap_or_default(), MAX_PROMPT_CONTEXT_LEN),
+        limit_text(
+            context.prompt_seed.unwrap_or_default(),
+            MAX_PROMPT_CONTEXT_LEN
+        ),
         limit_text(
             context.latest_agent_message.unwrap_or_default(),
             MAX_SUMMARY_CONTEXT_LEN
@@ -381,7 +387,11 @@ fn ai_fallback_commit_subject(branch_name: &str) -> String {
     }
 }
 
-fn ai_first_prompt_for_thread(state: &AiState, thread_id: &str, fallback_branch_name: &str) -> String {
+fn ai_first_prompt_for_thread(
+    state: &AiState,
+    thread_id: &str,
+    fallback_branch_name: &str,
+) -> String {
     ai_first_prompt_seed_for_thread(state, thread_id)
         .or_else(|| {
             state

--- a/crates/hunk-git/src/mutation.rs
+++ b/crates/hunk-git/src/mutation.rs
@@ -155,7 +155,10 @@ pub fn working_copy_context_for_ai(
         .map(|(path, change)| format!("{} {}", worktree_change_status_code(*change), path))
         .collect::<Vec<_>>();
     if changes.len() > limited_files {
-        summary_lines.push(format!("... {} more file(s)", changes.len() - limited_files));
+        summary_lines.push(format!(
+            "... {} more file(s)",
+            changes.len() - limited_files
+        ));
     }
     let changed_files_summary = summary_lines.join("\n");
 


### PR DESCRIPTION
Retry empty-rollout read failures briefly during thread hydrate/metadata refresh, then treat remaining matches as non-fatal to avoid spurious AI error banners while thread loading continues. Also routes sync snapshot loading through the shared loader and adds targeted retry/error-classification tests.