### PR TITLE
Enable commit-and-push publishing for AI worktree threads

### DIFF
--- a/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
@@ -53,14 +53,7 @@ impl DiffViewer {
     }
 
     pub(super) fn ai_publish_blocker(&self) -> Option<String> {
-        let context = match self.ai_current_thread_git_action_context("publishing") {
-            Ok(context) => context,
-            Err(reason) => return Some(reason),
-        };
-        if context.start_mode != AiNewThreadStartMode::Local {
-            return Some("Direct push is only available for local threads.".to_string());
-        }
-        None
+        ai_publish_blocker_reason(self.ai_current_thread_git_action_context("publishing"))
     }
 
     pub(super) fn ai_open_pr_blocker(&self) -> Option<String> {
@@ -411,6 +404,12 @@ impl DiffViewer {
     }
 }
 
+fn ai_publish_blocker_reason(
+    context: Result<AiThreadGitActionContext, String>,
+) -> Option<String> {
+    context.err()
+}
+
 fn resolve_ai_commit_message_for_working_copy(
     generation_config: AiCodexGenerationConfig<'_>,
     repo_root: &std::path::Path,
@@ -463,5 +462,45 @@ fn activate_new_ai_review_branch(
                 return Err(err);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod ai_git_ops_tests {
+    use super::*;
+
+    fn test_git_action_context(start_mode: AiNewThreadStartMode) -> AiThreadGitActionContext {
+        AiThreadGitActionContext {
+            repo_root: std::path::PathBuf::from("/repo"),
+            thread_id: "thread-1".to_string(),
+            branch_name: "feature/ai-thread".to_string(),
+            start_mode,
+        }
+    }
+
+    #[test]
+    fn publish_blocker_allows_local_threads() {
+        assert_eq!(
+            ai_publish_blocker_reason(Ok(test_git_action_context(AiNewThreadStartMode::Local))),
+            None
+        );
+    }
+
+    #[test]
+    fn publish_blocker_allows_worktree_threads() {
+        assert_eq!(
+            ai_publish_blocker_reason(Ok(test_git_action_context(
+                AiNewThreadStartMode::Worktree,
+            ))),
+            None
+        );
+    }
+
+    #[test]
+    fn publish_blocker_preserves_context_errors() {
+        assert_eq!(
+            ai_publish_blocker_reason(Err("Select a thread before publishing.".to_string())),
+            Some("Select a thread before publishing.".to_string())
+        );
     }
 }

--- a/crates/hunk-desktop/src/app/render/ai.rs
+++ b/crates/hunk-desktop/src/app/render/ai.rs
@@ -779,96 +779,77 @@ impl DiffViewer {
                                                                 )
                                                                 .child({
                                                                     let view = view.clone();
-                                                                    if selected_thread_start_mode
-                                                                        == Some(AiNewThreadStartMode::Local)
-                                                                    {
-                                                                        let push_label = format!(
-                                                                            "Commit and Push to {}",
-                                                                            active_branch
-                                                                        );
-                                                                        Button::new("ai-publish-local-thread")
-                                                                            .compact()
-                                                                            .outline()
-                                                                            .with_size(
-                                                                                gpui_component::Size::Small,
-                                                                            )
-                                                                            .rounded(px(8.0))
-                                                                            .loading(
-                                                                                ai_commit_and_push_loading
-                                                                                    || ai_open_pr_loading,
-                                                                            )
-                                                                            .dropdown_caret(true)
-                                                                            .label("Publish")
-                                                                            .tooltip(
-                                                                                ai_publish_blocker
-                                                                                    .clone()
-                                                                                    .unwrap_or_else(
-                                                                                        || "Commit and push this branch directly, or create a review branch and open PR/MR."
-                                                                                            .to_string(),
-                                                                                    ),
-                                                                            )
-                                                                            .disabled(
-                                                                                ai_publish_disabled,
-                                                                            )
-                                                                            .dropdown_menu(
-                                                                                move |menu, _, _| {
-                                                                                    menu.item(
-                                                                                        PopupMenuItem::new(
-                                                                                            push_label.clone(),
-                                                                                        )
+                                                                    let push_label = format!(
+                                                                        "Commit and Push to {}",
+                                                                        active_branch
+                                                                    );
+                                                                    let publish_tooltip =
+                                                                        ai_publish_blocker.clone().unwrap_or_else(|| {
+                                                                            match selected_thread_start_mode {
+                                                                                Some(AiNewThreadStartMode::Local) => {
+                                                                                    "Commit and push this branch directly, or create a review branch and open PR/MR."
+                                                                                        .to_string()
+                                                                                }
+                                                                                Some(AiNewThreadStartMode::Worktree) => {
+                                                                                    "Commit and push this worktree branch directly, or open PR/MR for the current branch."
+                                                                                        .to_string()
+                                                                                }
+                                                                                None => "Commit and push this branch directly, or open PR/MR for it."
+                                                                                    .to_string(),
+                                                                            }
+                                                                        });
+                                                                    Button::new("ai-publish-thread")
+                                                                        .compact()
+                                                                        .outline()
+                                                                        .with_size(
+                                                                            gpui_component::Size::Small,
+                                                                        )
+                                                                        .rounded(px(8.0))
+                                                                        .loading(
+                                                                            ai_commit_and_push_loading
+                                                                                || ai_open_pr_loading,
+                                                                        )
+                                                                        .dropdown_caret(true)
+                                                                        .label("Publish")
+                                                                        .tooltip(publish_tooltip)
+                                                                        .disabled(
+                                                                            ai_publish_disabled
+                                                                                || ai_open_pr_disabled,
+                                                                        )
+                                                                        .dropdown_menu(
+                                                                            move |menu, _, _| {
+                                                                                menu.item(
+                                                                                    PopupMenuItem::new(
+                                                                                        push_label.clone(),
+                                                                                    )
+                                                                                    .on_click({
+                                                                                        let view = view
+                                                                                            .clone();
+                                                                                        move |_, _, cx| {
+                                                                                            view.update(cx, |this, cx| {
+                                                                                                this.ai_commit_and_push_for_current_thread(cx);
+                                                                                            });
+                                                                                        }
+                                                                                    }),
+                                                                                )
+                                                                                .item(
+                                                                                    PopupMenuItem::separator(),
+                                                                                )
+                                                                                .item(
+                                                                                    PopupMenuItem::new("Open PR")
                                                                                         .on_click({
                                                                                             let view = view
                                                                                                 .clone();
                                                                                             move |_, _, cx| {
                                                                                                 view.update(cx, |this, cx| {
-                                                                                                    this.ai_commit_and_push_for_current_thread(cx);
+                                                                                                    this.ai_open_pr_for_current_thread(cx);
                                                                                                 });
                                                                                             }
                                                                                         }),
-                                                                                    )
-                                                                                    .item(
-                                                                                        PopupMenuItem::separator(),
-                                                                                    )
-                                                                                    .item(
-                                                                                        PopupMenuItem::new("Open PR")
-                                                                                            .on_click({
-                                                                                                let view = view
-                                                                                                    .clone();
-                                                                                                move |_, _, cx| {
-                                                                                                    view.update(cx, |this, cx| {
-                                                                                                        this.ai_open_pr_for_current_thread(cx);
-                                                                                                    });
-                                                                                                }
-                                                                                            }),
-                                                                                    )
-                                                                                },
-                                                                            )
-                                                                            .into_any_element()
-                                                                    } else {
-                                                                        Button::new("ai-open-pr")
-                                                                            .compact()
-                                                                            .outline()
-                                                                            .with_size(
-                                                                                gpui_component::Size::Small,
-                                                                            )
-                                                                            .rounded(px(8.0))
-                                                                            .loading(ai_open_pr_loading)
-                                                                            .label("Open PR")
-                                                                            .tooltip(
-                                                                                ai_open_pr_blocker
-                                                                                    .clone()
-                                                                                    .unwrap_or_else(
-                                                                                        || "Commit, push, and open PR/MR for the current AI thread.".to_string(),
-                                                                                    ),
-                                                                            )
-                                                                            .disabled(ai_open_pr_disabled)
-                                                                            .on_click(move |_, _, cx| {
-                                                                                view.update(cx, |this, cx| {
-                                                                                    this.ai_open_pr_for_current_thread(cx);
-                                                                                });
-                                                                            })
-                                                                            .into_any_element()
-                                                                    }
+                                                                                )
+                                                                            },
+                                                                        )
+                                                                        .into_any_element()
                                                                 })
                                                                 .when(self.ai_mad_max_mode, |this| {
                                                                     this.child(


### PR DESCRIPTION
Use the same Publish dropdown for local and worktree AI threads so worktree users can either commit and push to the current branch or open a PR. Remove the local-only publish blocker and add tests to ensure worktree/local threads are publishable while context errors still surface.