### PR TITLE
Fix thread archive rollout errors across worktree runtimes

### DIFF
--- a/crates/hunk-codex/src/state.rs
+++ b/crates/hunk-codex/src/state.rs
@@ -518,7 +518,7 @@ impl AiState {
             .threads
             .entry(thread_id.clone())
             .or_insert_with(|| ThreadSummary {
-                id: thread_id,
+                id: thread_id.clone(),
                 cwd: String::new(),
                 title: None,
                 status,
@@ -533,6 +533,13 @@ impl AiState {
 
         thread.status = status;
         thread.last_sequence = sequence;
+        if matches!(
+            thread.status,
+            ThreadLifecycleStatus::Archived | ThreadLifecycleStatus::Closed
+        ) {
+            self.active_thread_by_cwd
+                .retain(|_, active_thread_id| active_thread_id != &thread_id);
+        }
         ApplyOutcome::Applied
     }
 

--- a/crates/hunk-codex/src/threads/notifications.rs
+++ b/crates/hunk-codex/src/threads/notifications.rs
@@ -17,6 +17,12 @@ impl ThreadService {
         Ok(response)
     }
 
+    pub fn mark_thread_archived_if_known(&mut self, thread_id: String) {
+        if self.is_known_thread(&thread_id) {
+            self.apply_event(ReducerEvent::ThreadArchived { thread_id });
+        }
+    }
+
     pub fn unarchive_thread(
         &mut self,
         session: &mut JsonRpcSession,

--- a/crates/hunk-codex/tests/thread_service.rs
+++ b/crates/hunk-codex/tests/thread_service.rs
@@ -274,6 +274,7 @@ fn archive_and_unarchive_round_trip_updates_state() {
             .status,
         ThreadLifecycleStatus::Archived
     );
+    assert_eq!(service.active_thread_for_workspace(), None);
 
     service
         .unarchive_thread(&mut session, "thread-archive".to_string(), TIMEOUT)

--- a/crates/hunk-desktop/src/app.rs
+++ b/crates/hunk-desktop/src/app.rs
@@ -1250,8 +1250,6 @@ struct DiffViewer {
     ai_timeline_follow_output: bool,
     ai_thread_list_scroll_handle: ScrollHandle,
     ai_thread_inline_toast: Option<String>,
-    ai_thread_inline_toast_epoch: usize,
-    ai_thread_inline_toast_task: Task<()>,
     ai_git_progress: Option<AiGitProgressState>,
     ai_thread_title_refresh_state_by_thread: BTreeMap<String, AiThreadTitleRefreshState>,
     ai_timeline_list_state: ListState,

--- a/crates/hunk-desktop/src/app/ai_runtime/core.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/core.rs
@@ -510,43 +510,19 @@ impl AiWorkerRuntime {
                 self.emit_snapshot_after_sync(event_tx)?;
             }
             AiWorkerCommand::ArchiveThread { thread_id } => {
-                let was_active =
-                    self.service.active_thread_for_workspace() == Some(thread_id.as_str());
-                self.service.archive_thread(
+                let archive_result = self.service.archive_thread(
                     &mut self.session,
                     thread_id.clone(),
                     self.request_timeout,
-                )?;
-                if was_active {
-                    let replacement_thread_id = self
-                        .service
-                        .state()
-                        .threads
-                        .values()
-                        .filter(|thread| {
-                            thread.cwd == self.workspace_key
-                                && thread.status != ThreadLifecycleStatus::Archived
-                                && thread.id != thread_id
-                        })
-                        .max_by(|left, right| {
-                            left.created_at
-                                .cmp(&right.created_at)
-                                .then_with(|| left.id.cmp(&right.id))
-                        })
-                        .map(|thread| thread.id.clone());
-                    if let Some(next_thread_id) = replacement_thread_id {
-                        self.service
-                            .state_mut()
-                            .set_active_thread_for_cwd(
-                                self.workspace_key.clone(),
-                                next_thread_id,
-                            );
-                    } else {
-                        self.service
-                            .state_mut()
-                            .active_thread_by_cwd
-                            .remove(self.workspace_key.as_str());
+                );
+                match archive_result {
+                    Ok(_) => {
+                        self.update_active_thread_after_archive(thread_id.as_str());
                     }
+                    Err(error)
+                        if is_missing_thread_rollout_error(&error)
+                            && self.reconcile_missing_rollout_thread_error(thread_id.as_str())? => {}
+                    Err(error) => return Err(error),
                 }
                 self.emit_snapshot_after_sync(event_tx)?;
             }
@@ -805,6 +781,9 @@ impl AiWorkerRuntime {
                     "ignoring transient rollout load error while hydrating thread snapshot"
                 );
             }
+            Err(error)
+                if is_missing_thread_rollout_error(&error)
+                    && self.reconcile_missing_rollout_thread_error(read_thread_id.as_str())? => {}
             Err(error) => return Err(error),
         }
         self.hydrate_thread_from_rollout_fallback_if_needed(read_thread_id.as_str());
@@ -832,6 +811,9 @@ impl AiWorkerRuntime {
                     "ignoring transient rollout load error while refreshing thread metadata"
                 );
             }
+            Err(error)
+                if is_missing_thread_rollout_error(&error)
+                    && self.reconcile_missing_rollout_thread_error(thread_id.as_str())? => {}
             Err(error) => return Err(error),
         }
         Ok(())

--- a/crates/hunk-desktop/src/app/ai_runtime/helpers.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/helpers.rs
@@ -51,6 +51,18 @@ fn is_transient_rollout_load_error(error: &CodexIntegrationError) -> bool {
         && normalized_message.contains("is empty")
 }
 
+fn is_missing_thread_rollout_error(error: &CodexIntegrationError) -> bool {
+    let CodexIntegrationError::JsonRpcServerError { code, message } = error else {
+        return false;
+    };
+    if *code != -32600 {
+        return false;
+    }
+
+    let normalized_message = message.to_ascii_lowercase();
+    normalized_message.contains("no rollout found for thread id")
+}
+
 fn retry_transient_rollout_load<T, F>(
     max_retries: usize,
     retry_delay: std::time::Duration,

--- a/crates/hunk-desktop/src/app/ai_runtime/sync.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/sync.rs
@@ -1,5 +1,13 @@
 impl AiWorkerRuntime {
     fn refresh_thread_list(&mut self) -> Result<(), CodexIntegrationError> {
+        let _ = self.refresh_thread_list_contains_thread(None)?;
+        Ok(())
+    }
+
+    fn refresh_thread_list_contains_thread(
+        &mut self,
+        thread_id: Option<&str>,
+    ) -> Result<bool, CodexIntegrationError> {
         let response =
             self.service
                 .list_threads(&mut self.session, None, Some(200), self.request_timeout)?;
@@ -11,7 +19,69 @@ impl AiWorkerRuntime {
                 .state_mut()
                 .set_active_thread_for_cwd(self.workspace_key.clone(), first_thread.id.clone());
         }
-        Ok(())
+        Ok(thread_id.is_some_and(|thread_id| {
+            response.data.iter().any(|thread| thread.id == thread_id)
+        }))
+    }
+
+    fn update_active_thread_after_archive(&mut self, archived_thread_id: &str) {
+        if self.service.active_thread_for_workspace() == Some(archived_thread_id) {
+            self.service
+                .state_mut()
+                .active_thread_by_cwd
+                .remove(self.workspace_key.as_str());
+        }
+
+        if self.service.active_thread_for_workspace().is_some() {
+            return;
+        }
+
+        let replacement_thread_id = self
+            .service
+            .state()
+            .threads
+            .values()
+            .filter(|thread| {
+                thread.cwd == self.workspace_key
+                    && thread.status != ThreadLifecycleStatus::Archived
+                    && thread.id != archived_thread_id
+            })
+            .max_by(|left, right| {
+                left.created_at
+                    .cmp(&right.created_at)
+                    .then_with(|| left.id.cmp(&right.id))
+            })
+            .map(|thread| thread.id.clone());
+
+        if let Some(next_thread_id) = replacement_thread_id {
+            self.service
+                .state_mut()
+                .set_active_thread_for_cwd(self.workspace_key.clone(), next_thread_id);
+        }
+    }
+
+    fn reconcile_missing_rollout_thread_error(
+        &mut self,
+        thread_id: &str,
+    ) -> Result<bool, CodexIntegrationError> {
+        if self
+            .service
+            .state()
+            .threads
+            .get(thread_id)
+            .is_some_and(|thread| thread.status == ThreadLifecycleStatus::Archived)
+        {
+            self.update_active_thread_after_archive(thread_id);
+            return Ok(true);
+        }
+
+        if self.refresh_thread_list_contains_thread(Some(thread_id))? {
+            return Ok(false);
+        }
+
+        self.service.mark_thread_archived_if_known(thread_id.to_string());
+        self.update_active_thread_after_archive(thread_id);
+        Ok(true)
     }
 
     fn hydrate_initial_timeline(&mut self) -> Result<(), CodexIntegrationError> {

--- a/crates/hunk-desktop/src/app/ai_runtime/tests.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/tests.rs
@@ -34,6 +34,7 @@ mod ai_tests {
     use super::dispatch_ai_worker_result;
     use super::reconnect_backoff;
     use super::is_transient_rollout_load_error;
+    use super::is_missing_thread_rollout_error;
     use super::map_command_approval_decision;
     use super::map_file_change_approval_decision;
     use super::panic_payload_message;
@@ -290,6 +291,28 @@ mod ai_tests {
             &CodexIntegrationError::JsonRpcServerError {
                 code: -32602,
                 message: "failed to load rollout '/tmp/rollout.jsonl' for thread thread-1: rollout at /tmp/rollout.jsonl is empty".to_string(),
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_thread_rollout_error_helper_matches_missing_rollout_server_errors_only() {
+        assert!(is_missing_thread_rollout_error(
+            &CodexIntegrationError::JsonRpcServerError {
+                code: -32600,
+                message: "no rollout found for thread id thread-1".to_string(),
+            }
+        ));
+        assert!(!is_missing_thread_rollout_error(
+            &CodexIntegrationError::JsonRpcServerError {
+                code: -32603,
+                message: "no rollout found for thread id thread-1".to_string(),
+            }
+        ));
+        assert!(!is_missing_thread_rollout_error(
+            &CodexIntegrationError::JsonRpcServerError {
+                code: -32600,
+                message: "failed to load rollout '/tmp/rollout.jsonl'".to_string(),
             }
         ));
     }

--- a/crates/hunk-desktop/src/app/controller/ai/core.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/core.rs
@@ -12,7 +12,6 @@ use hunk_domain::state::AppState;
 
 impl DiffViewer {
     const AI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(33);
-    const AI_THREAD_INLINE_TOAST_DURATION: Duration = Duration::from_millis(2200);
 
     pub(super) fn ensure_ai_runtime_started(&mut self, cx: &mut Context<Self>) {
         let Some(cwd) = self.ai_workspace_cwd() else {
@@ -540,46 +539,18 @@ impl DiffViewer {
         cx.notify();
     }
 
-    fn show_ai_thread_inline_toast(&mut self, message: impl Into<String>, cx: &mut Context<Self>) {
-        self.ai_thread_inline_toast_epoch = self.ai_thread_inline_toast_epoch.wrapping_add(1);
-        let epoch = self.ai_thread_inline_toast_epoch;
-        self.ai_thread_inline_toast = Some(message.into());
-        self.ai_thread_inline_toast_task = cx.spawn(async move |this, cx| {
-            cx.background_executor()
-                .timer(Self::AI_THREAD_INLINE_TOAST_DURATION)
-                .await;
-            let Some(this) = this.upgrade() else {
-                return;
-            };
-            this.update(cx, |this, cx| {
-                if this.ai_thread_inline_toast_epoch != epoch {
-                    return;
-                }
-                this.ai_thread_inline_toast = None;
-                cx.notify();
-            });
-        });
-        cx.notify();
-    }
-
     pub(super) fn ai_archive_thread_action(&mut self, thread_id: String, cx: &mut Context<Self>) {
-        if !self.send_ai_worker_command(
+        let workspace_key = self
+            .ai_thread_workspace_root(thread_id.as_str())
+            .map(|root| root.to_string_lossy().to_string());
+        if !self.send_ai_worker_command_for_workspace(
+            workspace_key.as_deref(),
             AiWorkerCommand::ArchiveThread {
                 thread_id: thread_id.clone(),
             },
+            true,
             cx,
-        ) {
-            return;
-        }
-
-        if self.ai_selected_thread_id.as_deref() == Some(thread_id.as_str()) {
-            self.ai_selected_thread_id = None;
-            self.ai_expanded_timeline_row_ids.clear();
-            self.ai_text_selection = None;
-            self.ai_timeline_follow_output = true;
-            self.ai_scroll_timeline_to_bottom = true;
-        }
-        self.show_ai_thread_inline_toast("Thread archived.", cx);
+        ) {}
     }
 
     pub(super) fn ai_toggle_timeline_row_expansion_action(
@@ -647,22 +618,6 @@ impl DiffViewer {
         self.ai_thread_summary(thread_id)
             .filter(|thread| thread.status != ThreadLifecycleStatus::Archived)
             .map(|thread| std::path::PathBuf::from(thread.cwd))
-    }
-
-    fn ai_active_thread_for_workspace_key(&self, workspace_key: &str) -> Option<String> {
-        self.ai_state_snapshot
-            .active_thread_for_cwd(workspace_key)
-            .map(ToOwned::to_owned)
-            .or_else(|| {
-                self.ai_workspace_states
-                    .get(workspace_key)
-                    .and_then(|state| {
-                        state
-                            .state_snapshot
-                            .active_thread_for_cwd(workspace_key)
-                            .map(ToOwned::to_owned)
-                    })
-            })
     }
 
     fn ai_pending_approval(&self, request_id: &str) -> Option<AiPendingApproval> {
@@ -1124,27 +1079,12 @@ impl DiffViewer {
     }
 
     pub(super) fn current_ai_thread_id(&self) -> Option<String> {
-        if self.ai_new_thread_draft_active || self.ai_pending_new_thread_selection {
-            return None;
-        }
-
-        if let Some(selected) = self.ai_selected_thread_id.as_ref()
-            && self
-                .ai_thread_summary(selected)
-                .is_some_and(|thread| thread.status != ThreadLifecycleStatus::Archived)
-        {
-            return Some(selected.clone());
-        }
-
-        self.ai_workspace_key_for_draft().and_then(|cwd| {
-            self.ai_active_thread_for_workspace_key(cwd.as_str())
-                .as_deref()
-                .and_then(|thread_id| {
-                    self.ai_thread_summary(thread_id)
-                        .filter(|thread| thread.status != ThreadLifecycleStatus::Archived)
-                        .map(|_| thread_id.to_string())
-                })
-        })
+        current_visible_thread_id_from_snapshot(
+            &self.ai_state_snapshot,
+            self.ai_selected_thread_id.as_deref(),
+            self.ai_workspace_key_for_draft().as_deref(),
+            self.ai_new_thread_draft_active || self.ai_pending_new_thread_selection,
+        )
     }
 
     pub(crate) fn ai_pending_thread_start_for_timeline(&self) -> Option<AiPendingThreadStart> {

--- a/crates/hunk-desktop/src/app/controller/ai/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/helpers.rs
@@ -485,6 +485,34 @@ fn should_sync_selected_thread_from_active_thread(
     selected_thread_id.is_none_or(|selected| !state.threads.contains_key(selected))
 }
 
+fn current_visible_thread_id_from_snapshot(
+    state: &hunk_codex::state::AiState,
+    selected_thread_id: Option<&str>,
+    workspace_key: Option<&str>,
+    preserving_workspace_draft: bool,
+) -> Option<String> {
+    if preserving_workspace_draft {
+        return None;
+    }
+
+    if let Some(selected_thread_id) = selected_thread_id
+        && state
+            .threads
+            .get(selected_thread_id)
+            .is_some_and(|thread| thread.status != ThreadLifecycleStatus::Archived)
+    {
+        return Some(selected_thread_id.to_string());
+    }
+
+    let workspace_key = workspace_key?;
+    let active_thread_id = state.active_thread_for_cwd(workspace_key)?;
+    state
+        .threads
+        .get(active_thread_id)
+        .filter(|thread| thread.status != ThreadLifecycleStatus::Archived)
+        .map(|_| active_thread_id.to_string())
+}
+
 pub(crate) fn ai_prompt_send_waiting_on_connection(
     connection_state: AiConnectionState,
     bootstrap_loading: bool,

--- a/crates/hunk-desktop/src/app/controller/ai/tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests.rs
@@ -21,6 +21,7 @@ mod ai_tests {
     use super::bundled_codex_executable_candidates;
     use super::codex_runtime_binary_name;
     use super::codex_runtime_platform_dir;
+    use super::current_visible_thread_id_from_snapshot;
     use super::drain_ai_worker_events;
     use super::group_ai_timeline_rows_for_thread;
     use super::item_status_chip;
@@ -394,6 +395,37 @@ mod ai_tests {
         assert!(!workspace_state.new_thread_draft_active);
         assert!(!workspace_state.pending_new_thread_selection);
         assert!(workspace_state.error_message.is_none());
+    }
+
+    #[test]
+    fn current_visible_thread_id_from_snapshot_prefers_live_snapshot_threads_only() {
+        let mut state = AiState::default();
+        state.threads.insert(
+            "thread-active".to_string(),
+            ThreadSummary {
+                id: "thread-active".to_string(),
+                cwd: "/repo".to_string(),
+                title: Some("Active".to_string()),
+                status: ThreadLifecycleStatus::Idle,
+                created_at: 20,
+                updated_at: 20,
+                last_sequence: 2,
+            },
+        );
+        state
+            .active_thread_by_cwd
+            .insert("/repo".to_string(), "thread-active".to_string());
+
+        assert_eq!(
+            current_visible_thread_id_from_snapshot(
+                &state,
+                Some("thread-stale"),
+                Some("/repo"),
+                false,
+            )
+            .as_deref(),
+            Some("thread-active")
+        );
     }
 
     #[test]

--- a/crates/hunk-desktop/src/app/controller/core.rs
+++ b/crates/hunk-desktop/src/app/controller/core.rs
@@ -409,8 +409,6 @@ impl DiffViewer {
             ai_timeline_follow_output: true,
             ai_thread_list_scroll_handle: ScrollHandle::default(),
             ai_thread_inline_toast: None,
-            ai_thread_inline_toast_epoch: 0,
-            ai_thread_inline_toast_task: Task::ready(()),
             ai_git_progress: None,
             ai_thread_title_refresh_state_by_thread: BTreeMap::new(),
             ai_timeline_list_state: ListState::new(0, ListAlignment::Top, px(360.0)),


### PR DESCRIPTION
Route archive commands to the thread-owning workspace runtime and reconcile `-32600 no rollout found for thread id` as a post-archive state sync instead of surfacing a failure. This avoids random false error banners when archive succeeds but rollout data is already gone.