### PR TITLE
Fix AI thread fallback precedence and git commit args

### DIFF
--- a/crates/hunk-desktop/src/app/controller/ai/core.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/core.rs
@@ -1120,10 +1120,19 @@ impl DiffViewer {
     }
 
     pub(super) fn current_ai_thread_id(&self) -> Option<String> {
+        let selected_thread_workspace_root = self
+            .ai_selected_thread_id
+            .as_deref()
+            .and_then(|thread_id| self.ai_thread_workspace_root(thread_id));
+        let fallback_workspace_key = current_visible_thread_fallback_workspace_key(
+            self.ai_worker_workspace_key.as_deref(),
+            selected_thread_workspace_root.as_deref(),
+            self.ai_workspace_key_for_draft().as_deref(),
+        );
         current_visible_thread_id_from_snapshot(
             &self.ai_state_snapshot,
             self.ai_selected_thread_id.as_deref(),
-            self.ai_workspace_key_for_draft().as_deref(),
+            fallback_workspace_key.as_deref(),
             self.ai_new_thread_draft_active || self.ai_pending_new_thread_selection,
         )
     }

--- a/crates/hunk-desktop/src/app/controller/ai/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/helpers.rs
@@ -520,6 +520,21 @@ fn should_sync_selected_thread_from_active_thread(
     selected_thread_id.is_none_or(|selected| !state.threads.contains_key(selected))
 }
 
+fn current_visible_thread_fallback_workspace_key(
+    visible_workspace_key: Option<&str>,
+    selected_thread_workspace_root: Option<&std::path::Path>,
+    draft_workspace_key: Option<&str>,
+) -> Option<String> {
+    visible_workspace_key
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            selected_thread_workspace_root.map(|workspace_root| {
+                workspace_root.to_string_lossy().to_string()
+            })
+        })
+        .or_else(|| draft_workspace_key.map(ToOwned::to_owned))
+}
+
 fn current_visible_thread_id_from_snapshot(
     state: &hunk_codex::state::AiState,
     selected_thread_id: Option<&str>,

--- a/crates/hunk-desktop/src/app/controller/ai/tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests.rs
@@ -22,6 +22,7 @@ mod ai_tests {
     use super::codex_runtime_binary_name;
     use super::codex_runtime_platform_dir;
     use super::current_visible_thread_id_from_snapshot;
+    use super::current_visible_thread_fallback_workspace_key;
     use super::drain_ai_worker_events;
     use super::group_ai_timeline_rows_for_thread;
     use super::item_status_chip;
@@ -524,6 +525,85 @@ mod ai_tests {
             )
             .as_deref(),
             Some("thread-active")
+        );
+    }
+
+    #[test]
+    fn current_visible_thread_fallback_workspace_key_prefers_visible_workspace_over_stale_draft() {
+        assert_eq!(
+            current_visible_thread_fallback_workspace_key(
+                Some("/repo"),
+                None,
+                Some("/repo/worktrees/task-1"),
+            )
+            .as_deref(),
+            Some("/repo")
+        );
+    }
+
+    #[test]
+    fn current_visible_thread_fallback_workspace_key_prefers_selected_thread_workspace_over_stale_draft() {
+        assert_eq!(
+            current_visible_thread_fallback_workspace_key(
+                None,
+                Some(std::path::Path::new("/repo")),
+                Some("/repo/worktrees/task-1"),
+            )
+            .as_deref(),
+            Some("/repo")
+        );
+    }
+
+    #[test]
+    fn current_visible_thread_id_from_snapshot_uses_visible_workspace_before_stale_draft_workspace() {
+        let mut state = AiState::default();
+        state.threads.insert(
+            "thread-local".to_string(),
+            ThreadSummary {
+                id: "thread-local".to_string(),
+                cwd: "/repo".to_string(),
+                title: Some("Local".to_string()),
+                status: ThreadLifecycleStatus::Idle,
+                created_at: 10,
+                updated_at: 10,
+                last_sequence: 1,
+            },
+        );
+        state.threads.insert(
+            "thread-worktree".to_string(),
+            ThreadSummary {
+                id: "thread-worktree".to_string(),
+                cwd: "/repo/worktrees/task-1".to_string(),
+                title: Some("Worktree".to_string()),
+                status: ThreadLifecycleStatus::Idle,
+                created_at: 20,
+                updated_at: 20,
+                last_sequence: 2,
+            },
+        );
+        state
+            .active_thread_by_cwd
+            .insert("/repo".to_string(), "thread-local".to_string());
+        state.active_thread_by_cwd.insert(
+            "/repo/worktrees/task-1".to_string(),
+            "thread-worktree".to_string(),
+        );
+
+        let workspace_key = current_visible_thread_fallback_workspace_key(
+            Some("/repo"),
+            None,
+            Some("/repo/worktrees/task-1"),
+        );
+
+        assert_eq!(
+            current_visible_thread_id_from_snapshot(
+                &state,
+                Some("missing-thread"),
+                workspace_key.as_deref(),
+                false,
+            )
+            .as_deref(),
+            Some("thread-local")
         );
     }
 

--- a/crates/hunk-git/src/mutation.rs
+++ b/crates/hunk-git/src/mutation.rs
@@ -440,12 +440,7 @@ fn run_git_commit(repo: &git2::Repository, message: &str) -> Result<()> {
         .ok_or_else(|| anyhow!("committing without a worktree is not supported"))?;
     let output = Command::new("git")
         .current_dir(workdir)
-        .args([
-            "commit",
-            "--quiet",
-            "--cleanup=verbatim",
-            "-m",
-        ])
+        .args(["commit", "--quiet", "--cleanup=verbatim", "-m"])
         .arg(message)
         .output()
         .context("failed to launch git commit")?;


### PR DESCRIPTION
Prefer the visible AI runtime workspace first, then the selected thread workspace, and only then the draft workspace so stale draft worktree keys cannot repeatedly auto-switch the active thread. Add regression tests for stale-draft/worktree precedence. Also remove the duplicated "commit" argv segment in hunk-git commit execution.