### PR TITLE
Hide no-turns empty state while first prompt is pending

### DIFF
--- a/crates/hunk-desktop/src/app/render/ai.rs
+++ b/crates/hunk-desktop/src/app/render/ai.rs
@@ -84,6 +84,10 @@ impl DiffViewer {
             timeline_visible_row_ids.len() == previous_timeline_row_count,
         );
         let ai_timeline_follow_output = self.ai_timeline_follow_output;
+        let show_no_turns_empty_state = ai_should_show_no_turns_empty_state(
+            timeline_visible_turn_count,
+            pending_thread_start.is_some(),
+        );
         let timeline_loading =
             show_global_loading_overlay && selected_thread_id.is_some() && timeline_visible_row_ids.is_empty();
         let show_select_thread_empty_state =
@@ -1156,7 +1160,7 @@ impl DiffViewer {
                                                             })
                                                             .size_full()
                                                             .with_sizing_behavior(ListSizingBehavior::Auto);
-                                                            this.when(timeline_visible_turn_count == 0, |this| {
+                                                            this.when(show_no_turns_empty_state, |this| {
                                                                 this.child(
                                                                     div()
                                                                         .rounded_md()
@@ -1385,6 +1389,13 @@ fn ai_render_composer_feedback_strip(
 
     ai_current_composer_activity(this)
         .map(|activity| ai_render_composer_activity_strip(this, &activity, is_dark, cx))
+}
+
+fn ai_should_show_no_turns_empty_state(
+    visible_turn_count: usize,
+    has_pending_thread_start: bool,
+) -> bool {
+    visible_turn_count == 0 && !has_pending_thread_start
 }
 
 fn ai_composer_status_tone(status: &str) -> Option<AiComposerStatusTone> {

--- a/crates/hunk-desktop/src/app/render/ai_helpers/tests.rs
+++ b/crates/hunk-desktop/src/app/render/ai_helpers/tests.rs
@@ -6,6 +6,7 @@ mod ai_helper_tests {
     use super::ai_command_execution_display_details;
     use super::ai_composer_status_tone;
     use super::ai_collaboration_picker_label;
+    use super::ai_should_show_no_turns_empty_state;
     use super::ai_tool_compact_summary;
     use super::ai_thread_display_title;
     use super::ai_thread_status_text;
@@ -115,6 +116,13 @@ mod ai_helper_tests {
         assert_eq!(ai_item_display_label("userMessage"), "User");
         assert_eq!(ai_item_display_label("agentMessage"), "Agent");
         assert_eq!(ai_item_display_label("unknownKind"), "unknownKind");
+    }
+
+    #[test]
+    fn no_turns_empty_state_is_hidden_while_first_prompt_is_pending() {
+        assert!(ai_should_show_no_turns_empty_state(0, false));
+        assert!(!ai_should_show_no_turns_empty_state(0, true));
+        assert!(!ai_should_show_no_turns_empty_state(1, false));
     }
 
     #[test]


### PR DESCRIPTION
Prevent a brief empty-state flash in newly created threads by gating the "No turns yet" card on pending thread start state; adds a regression test for the helper logic.