### PR TITLE
Avoid redundant startup refresh and cache nested repo path checks

### DIFF
--- a/crates/hunk-desktop/src/app.rs
+++ b/crates/hunk-desktop/src/app.rs
@@ -75,7 +75,8 @@ use refresh_policy::{
     SnapshotRefreshRequest, diff_state_changed, line_stats_paths_from_dirty_paths,
     missing_line_stat_paths, repo_watch_refresh_request, should_refresh_line_stats_after_snapshot,
     should_reload_diff_after_snapshot, should_reload_repo_tree_after_snapshot,
-    should_run_cold_start_reconcile, should_scroll_selected_after_reload,
+    should_request_startup_git_workspace_refresh, should_run_cold_start_reconcile,
+    should_scroll_selected_after_reload,
 };
 use review_compare_picker::{
     ReviewComparePickerDelegate, ReviewCompareSourceOption, build_review_compare_picker_delegate,

--- a/crates/hunk-desktop/src/app/controller/core.rs
+++ b/crates/hunk-desktop/src/app/controller/core.rs
@@ -958,7 +958,19 @@ impl DiffViewer {
         if self.workspace_view_mode == WorkspaceViewMode::Ai {
             self.refresh_ai_repo_thread_catalog(cx);
         }
-        self.request_git_workspace_refresh(true, cx);
+        let selected_target_is_primary = self
+            .workspace_targets
+            .iter()
+            .find(|target| target.is_active)
+            .is_some_and(|target| {
+                matches!(
+                    target.kind,
+                    hunk_git::worktree::WorkspaceTargetKind::PrimaryCheckout
+                )
+            });
+        if should_request_startup_git_workspace_refresh(selected_target_is_primary) {
+            self.request_git_workspace_refresh(true, cx);
+        }
     }
 
     fn activate_workspace_target(&mut self, target_id: String, cx: &mut Context<Self>) {

--- a/crates/hunk-desktop/src/app/refresh_policy.rs
+++ b/crates/hunk-desktop/src/app/refresh_policy.rs
@@ -159,6 +159,12 @@ pub(super) const fn should_run_cold_start_reconcile(
         && matches!(behavior, SnapshotRefreshBehavior::RefreshWorkingCopy)
 }
 
+pub(super) const fn should_request_startup_git_workspace_refresh(
+    selected_target_is_primary: bool,
+) -> bool {
+    !selected_target_is_primary
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct GitActionRefreshPlan {
     pub(super) refresh_primary_snapshot: bool,

--- a/crates/hunk-desktop/tests/refresh_policy.rs
+++ b/crates/hunk-desktop/tests/refresh_policy.rs
@@ -10,8 +10,8 @@ use refresh_policy::{
     SnapshotRefreshRequest, diff_state_changed, line_stats_paths_from_dirty_paths,
     missing_line_stat_paths, post_git_action_refresh_plan, repo_watch_refresh_request,
     should_refresh_line_stats_after_snapshot, should_reload_diff_after_snapshot,
-    should_reload_repo_tree_after_snapshot, should_run_cold_start_reconcile,
-    should_scroll_selected_after_reload,
+    should_reload_repo_tree_after_snapshot, should_request_startup_git_workspace_refresh,
+    should_run_cold_start_reconcile, should_scroll_selected_after_reload,
 };
 
 #[test]
@@ -238,4 +238,10 @@ fn git_workspace_refresh_requests_replace_old_root_when_target_changes() {
 
     assert_eq!(merged.root, PathBuf::from("/tmp/repo-worktree"));
     assert!(!merged.refresh_recent_commits);
+}
+
+#[test]
+fn startup_git_workspace_refresh_only_runs_for_non_primary_targets() {
+    assert!(!should_request_startup_git_workspace_refresh(true));
+    assert!(should_request_startup_git_workspace_refresh(false));
 }

--- a/crates/hunk-git/src/git.rs
+++ b/crates/hunk-git/src/git.rs
@@ -19,7 +19,7 @@ use crate::worktree::{
 
 pub const MAX_REPO_TREE_ENTRIES: usize = 60_000;
 
-static NESTED_REPO_ROOTS_CACHE: LazyLock<Mutex<HashMap<PathBuf, BTreeSet<String>>>> =
+static NESTED_REPO_ROOTS_CACHE: LazyLock<Mutex<HashMap<PathBuf, NestedRepoPathCache>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -178,6 +178,12 @@ struct WorkspaceDiffEntry {
     content_signature: u64,
 }
 
+#[derive(Debug, Clone, Default)]
+struct NestedRepoPathCache {
+    nested_roots: BTreeSet<String>,
+    checked_paths: BTreeSet<String>,
+}
+
 #[derive(Debug, Clone)]
 struct FileState {
     kind: gix::objs::tree::EntryKind,
@@ -241,6 +247,53 @@ struct ResolvedWorkspaceFile {
     content_signature: u64,
     old_state: Option<FileState>,
     new_state: Option<FileState>,
+}
+
+struct NestedRepoFilter<'a> {
+    root: &'a Path,
+    cache: NestedRepoPathCache,
+}
+
+impl<'a> NestedRepoFilter<'a> {
+    fn load(root: &'a Path) -> Self {
+        let cache = nested_repo_roots_cache_guard()
+            .get(root)
+            .cloned()
+            .unwrap_or_default();
+        Self { root, cache }
+    }
+
+    fn contains_path(&mut self, path: &str) -> bool {
+        if path.is_empty() || path_is_within_nested_repo(path, &self.cache.nested_roots) {
+            return !path.is_empty();
+        }
+
+        let mut current = String::new();
+        for component in path.split('/') {
+            if component.is_empty() {
+                continue;
+            }
+            if !current.is_empty() {
+                current.push('/');
+            }
+            current.push_str(component);
+
+            if self.cache.checked_paths.contains(current.as_str()) {
+                continue;
+            }
+            if directory_is_repo_root(self.root.join(current.as_str()).as_path()) {
+                self.cache.nested_roots.insert(current);
+                return true;
+            }
+            self.cache.checked_paths.insert(current.clone());
+        }
+
+        false
+    }
+
+    fn persist(self) {
+        nested_repo_roots_cache_guard().insert(self.root.to_path_buf(), self.cache);
+    }
 }
 
 impl GitRepo {
@@ -858,7 +911,7 @@ fn collect_candidate_files(
     root: &Path,
     requested_paths: Option<&BTreeSet<String>>,
 ) -> Result<BTreeMap<String, CandidateFile>> {
-    let nested_repo_roots = cached_nested_repo_roots_from_fs(root)?;
+    let mut nested_repo_filter = NestedRepoFilter::load(root);
     let mut files = BTreeMap::<String, CandidateFile>::new();
     let iter = repo
         .status(gix::progress::Discard)?
@@ -877,7 +930,7 @@ fn collect_candidate_files(
         if repo_relative_path_is_within_managed_worktrees(path.as_str()) {
             continue;
         }
-        if path_is_within_nested_repo(path.as_str(), &nested_repo_roots) {
+        if nested_repo_filter.contains_path(path.as_str()) {
             continue;
         }
         if requested_paths.is_some_and(|paths| !paths.contains(path.as_str())) {
@@ -904,6 +957,7 @@ fn collect_candidate_files(
     }
 
     resolve_candidate_rename_sources(&mut files);
+    nested_repo_filter.persist();
     Ok(files)
 }
 
@@ -1551,7 +1605,7 @@ fn load_visible_repo_paths(repo: &gix::Repository, root: &Path) -> Result<BTreeS
 }
 
 fn collect_untracked_repo_paths(repo: &gix::Repository, root: &Path) -> Result<BTreeSet<String>> {
-    let nested_repo_roots = cached_nested_repo_roots_from_fs(root)?;
+    let mut nested_repo_filter = NestedRepoFilter::load(root);
     let mut paths = BTreeSet::new();
     let iter = repo
         .status(gix::progress::Discard)?
@@ -1577,12 +1631,13 @@ fn collect_untracked_repo_paths(repo: &gix::Repository, root: &Path) -> Result<B
         if repo_relative_path_is_within_managed_worktrees(path.as_str()) {
             continue;
         }
-        if path_is_within_nested_repo(path.as_str(), &nested_repo_roots) {
+        if nested_repo_filter.contains_path(path.as_str()) {
             continue;
         }
         paths.insert(path);
     }
 
+    nested_repo_filter.persist();
     Ok(paths)
 }
 
@@ -1672,63 +1727,6 @@ fn path_is_visible_or_ancestor(path: &str, visible_paths: &BTreeSet<String>) -> 
     visible_paths
         .iter()
         .any(|visible| visible.starts_with(&prefix))
-}
-
-fn cached_nested_repo_roots_from_fs(root: &Path) -> Result<BTreeSet<String>> {
-    let cache_key = root.to_path_buf();
-    if let Some(cached) = nested_repo_roots_cache_guard().get(&cache_key).cloned() {
-        return Ok(cached);
-    }
-
-    let roots = nested_repo_roots_from_fs(root)?;
-    nested_repo_roots_cache_guard().insert(cache_key, roots.clone());
-    Ok(roots)
-}
-
-fn nested_repo_roots_from_fs(root: &Path) -> Result<BTreeSet<String>> {
-    let mut nested_roots = BTreeSet::new();
-    collect_nested_repo_roots(root, root, &mut nested_roots)?;
-    Ok(nested_roots)
-}
-
-fn collect_nested_repo_roots(
-    root: &Path,
-    current: &Path,
-    nested_roots: &mut BTreeSet<String>,
-) -> Result<()> {
-    for child in read_dir_sorted(current)? {
-        let Ok(file_type) = child.file_type() else {
-            continue;
-        };
-        if !file_type.is_dir() {
-            continue;
-        }
-
-        let name = child.file_name();
-        let name = name.to_string_lossy();
-        if name == ".git" {
-            continue;
-        }
-
-        let child_path = child.path();
-        let Ok(relative) = child_path.strip_prefix(root) else {
-            continue;
-        };
-        let relative_path = normalize_path(relative.to_string_lossy().as_ref());
-        if repo_relative_path_is_within_managed_worktrees(relative_path.as_str()) {
-            continue;
-        }
-        if directory_is_repo_root(child_path.as_path()) {
-            if !relative_path.is_empty() {
-                nested_roots.insert(relative_path);
-            }
-            continue;
-        }
-
-        collect_nested_repo_roots(root, child_path.as_path(), nested_roots)?;
-    }
-
-    Ok(())
 }
 
 fn directory_is_repo_root(path: &Path) -> bool {
@@ -1962,7 +1960,7 @@ fn canonicalize_existing_path(path: &Path) -> Result<PathBuf> {
 }
 
 fn nested_repo_roots_cache_guard()
--> std::sync::MutexGuard<'static, HashMap<PathBuf, BTreeSet<String>>> {
+-> std::sync::MutexGuard<'static, HashMap<PathBuf, NestedRepoPathCache>> {
     match NESTED_REPO_ROOTS_CACHE.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),

--- a/crates/hunk-git/tests/read_path.rs
+++ b/crates/hunk-git/tests/read_path.rs
@@ -312,6 +312,61 @@ fn load_repo_tree_marks_ignored_entries_and_counts_visible_nodes() -> Result<()>
 }
 
 #[test]
+fn workflow_snapshot_excludes_non_ignored_nested_repo_contents() -> Result<()> {
+    let fixture = TempGitRepo::new()?;
+    fixture.write_file("src/main.rs", "fn main() {}\n")?;
+    fixture.commit_all("initial")?;
+
+    let nested_root = fixture.root().join("vendor/nested");
+    fs::create_dir_all(nested_root.join("src"))?;
+    let nested_repo = Repository::init(nested_root.as_path())?;
+    drop(nested_repo);
+    fs::write(nested_root.join("src/lib.rs"), "nested\n")?;
+
+    let full = load_workflow_snapshot(fixture.root())?;
+    let light = load_workflow_snapshot_without_refresh(fixture.root())?;
+    let entries = load_repo_tree(fixture.root())?;
+
+    assert!(full.files.is_empty());
+    assert_eq!(light.files, full.files);
+    assert!(
+        entries
+            .iter()
+            .all(|entry| entry.path != "vendor/nested" && !entry.path.starts_with("vendor/nested/"))
+    );
+
+    Ok(())
+}
+
+#[test]
+fn workflow_snapshot_skips_nested_repo_contents_inside_ignored_directories() -> Result<()> {
+    let fixture = TempGitRepo::new()?;
+    fixture.write_file(".gitignore", "target-shared/\n")?;
+    fixture.commit_all("initial")?;
+
+    let nested_root = fixture.root().join("target-shared/cache/repo");
+    fs::create_dir_all(nested_root.join("src"))?;
+    let nested_repo = Repository::init(nested_root.as_path())?;
+    drop(nested_repo);
+    fs::write(nested_root.join("src/lib.rs"), "nested\n")?;
+
+    let workflow = load_workflow_snapshot_without_refresh(fixture.root())?;
+    let entries = load_repo_tree(fixture.root())?;
+
+    assert!(workflow.files.is_empty());
+    assert!(entries.iter().any(|entry| {
+        entry.path == "target-shared" && entry.kind == RepoTreeEntryKind::Directory && entry.ignored
+    }));
+    assert!(
+        entries
+            .iter()
+            .all(|entry| !entry.path.starts_with("target-shared/cache"))
+    );
+
+    Ok(())
+}
+
+#[test]
 fn file_line_stats_for_paths_only_returns_requested_changed_files() -> Result<()> {
     let fixture = TempGitRepo::new()?;
     fixture.write_file("src/lib.rs", "one\ntwo\n")?;


### PR DESCRIPTION
Only request startup git workspace refresh when the active target is not the primary checkout, reducing unnecessary cold-start work. Replace eager nested-repo root scanning with an incremental path-probe cache (nested roots + checked paths) used by status/untracked collection, and add regression tests for nested repos (including inside ignored directories).