### PR TITLE
Add lightweight cross-platform PR build workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,112 @@
+name: PR Build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - ".github/workflows/pr-build.yml"
+      - ".cargo/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "justfile"
+      - "crates/**"
+      - "scripts/build_linux.sh"
+      - "scripts/build_windows.sh"
+      - "scripts/resolve_cargo_target_dir.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-latest
+            resolve_target_dir: |
+              echo "CARGO_TARGET_DIR=$(./scripts/resolve_cargo_target_dir.sh "$GITHUB_WORKSPACE")" >> "$GITHUB_ENV"
+          - name: macOS
+            os: macos-latest
+            resolve_target_dir: |
+              echo "CARGO_TARGET_DIR=$(./scripts/resolve_cargo_target_dir.sh "$GITHUB_WORKSPACE")" >> "$GITHUB_ENV"
+          - name: Windows
+            os: windows-latest
+            resolve_target_dir: |
+              $targetDir = bash ./scripts/resolve_cargo_target_dir.sh $env:GITHUB_WORKSPACE
+              "CARGO_TARGET_DIR=$targetDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve shared cargo target dir
+        if: runner.os != 'Windows'
+        run: ${{ matrix.resolve_target_dir }}
+        shell: bash
+
+      - name: Resolve shared cargo target dir
+        if: runner.os == 'Windows'
+        run: ${{ matrix.resolve_target_dir }}
+        shell: pwsh
+
+      - name: Cache cargo registry and Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pr-build-${{ runner.os }}-desktop
+          workspaces: |
+            . -> target-shared
+          cache-on-failure: "true"
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            clang \
+            cmake \
+            libasound2-dev \
+            libfontconfig-dev \
+            libgit2-dev \
+            libglib2.0-dev \
+            libssl-dev \
+            libvulkan1 \
+            libwayland-dev \
+            libx11-xcb-dev \
+            libxkbcommon-x11-dev \
+            libzstd-dev \
+            pkg-config
+        shell: bash
+
+      - name: Build hunk-desktop
+        if: runner.os != 'Windows'
+        run: cargo build -p hunk-desktop --locked --profile ci
+        shell: bash
+
+      - name: Build hunk-desktop
+        if: runner.os == 'Windows'
+        run: cargo build -p hunk-desktop --locked --profile ci
+        shell: pwsh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
 ]
 default-members = ["crates/hunk-desktop"]
 resolver = "2"
+
+[profile.ci]
+inherits = "dev"
+debug = 0


### PR DESCRIPTION
Run a compile-only GitHub Actions matrix on Linux, macOS, and Windows for pull requests, with stale-run cancellation and build-focused caching to keep GPUI validation fast. Add a `ci` Cargo profile (`inherits = "dev"`, `debug = 0`) to reduce compile overhead.