### PR TITLE
Harden comment DB IDs and centralize migration execution

### DIFF
--- a/crates/hunk-domain/src/db/comments.rs
+++ b/crates/hunk-domain/src/db/comments.rs
@@ -206,6 +206,7 @@ impl DatabaseStore {
     pub fn create_comment(&self, input: &NewComment) -> Result<CommentRecord> {
         let id = next_comment_id();
         let now = now_unix_ms();
+        let row_stable_id = input.row_stable_id.map(sql_u64_to_i64).transpose()?;
 
         let conn = self.open_connection()?;
         conn.execute(
@@ -220,7 +221,7 @@ impl DatabaseStore {
                 input.line_side.as_str(),
                 input.old_line.map(i64::from),
                 input.new_line.map(i64::from),
-                input.row_stable_id.map(|value| value as i64),
+                row_stable_id,
                 input.hunk_header,
                 input.line_text,
                 input.context_before,
@@ -234,19 +235,13 @@ impl DatabaseStore {
         )
         .context("failed to insert comment")?;
 
-        self.get_comment(&id)?
+        get_comment_with_connection(&conn, &id)?
             .ok_or_else(|| anyhow!("inserted comment id {id} was not found"))
     }
 
     pub fn get_comment(&self, id: &str) -> Result<Option<CommentRecord>> {
         let conn = self.open_connection()?;
-        let mut stmt = conn
-            .prepare(sql::comments::SELECT_BY_ID)
-            .context("failed to prepare select comment by id query")?;
-
-        stmt.query_row(params![id], map_comment_row)
-            .optional()
-            .context("failed to query comment by id")
+        get_comment_with_connection(&conn, id)
     }
 
     pub fn list_comments(
@@ -314,27 +309,23 @@ impl DatabaseStore {
         };
 
         let mut conn = self.open_connection()?;
-        let tx = conn
-            .transaction()
-            .context("failed to start sqlite transaction for status batch update")?;
-        let mut stmt = tx
-            .prepare(sql::comments::UPDATE_STATUS)
-            .context("failed to prepare status batch update statement")?;
-        let mut updated = 0usize;
-        for id in ids {
-            updated += stmt
-                .execute(params![
+        execute_many_comment_ids(
+            &mut conn,
+            sql::comments::UPDATE_STATUS,
+            ids,
+            "failed to start sqlite transaction for status batch update",
+            "failed to prepare status batch update statement",
+            "failed to commit status batch update transaction",
+            |stmt, id| {
+                stmt.execute(params![
                     id,
                     status.as_str(),
                     stale_reason_value,
                     updated_at_unix_ms,
                 ])
-                .with_context(|| format!("failed to batch update status for comment {id}"))?;
-        }
-        drop(stmt);
-        tx.commit()
-            .context("failed to commit status batch update transaction")?;
-        Ok(updated)
+                .with_context(|| format!("failed to batch update status for comment {id}"))
+            },
+        )
     }
 
     pub fn touch_comment_seen(&self, id: &str, seen_at_unix_ms: i64) -> Result<bool> {
@@ -351,22 +342,18 @@ impl DatabaseStore {
         }
 
         let mut conn = self.open_connection()?;
-        let tx = conn
-            .transaction()
-            .context("failed to start sqlite transaction for last_seen batch update")?;
-        let mut stmt = tx
-            .prepare(sql::comments::TOUCH_SEEN)
-            .context("failed to prepare last_seen batch update statement")?;
-        let mut updated = 0usize;
-        for id in ids {
-            updated += stmt
-                .execute(params![id, seen_at_unix_ms])
-                .with_context(|| format!("failed to batch update last_seen for comment {id}"))?;
-        }
-        drop(stmt);
-        tx.commit()
-            .context("failed to commit last_seen batch update transaction")?;
-        Ok(updated)
+        execute_many_comment_ids(
+            &mut conn,
+            sql::comments::TOUCH_SEEN,
+            ids,
+            "failed to start sqlite transaction for last_seen batch update",
+            "failed to prepare last_seen batch update statement",
+            "failed to commit last_seen batch update transaction",
+            |stmt, id| {
+                stmt.execute(params![id, seen_at_unix_ms])
+                    .with_context(|| format!("failed to batch update last_seen for comment {id}"))
+            },
+        )
     }
 
     pub fn delete_comment(&self, id: &str) -> Result<bool> {
@@ -383,22 +370,18 @@ impl DatabaseStore {
         }
 
         let mut conn = self.open_connection()?;
-        let tx = conn
-            .transaction()
-            .context("failed to start sqlite transaction for comment batch delete")?;
-        let mut stmt = tx
-            .prepare(sql::comments::DELETE_BY_ID)
-            .context("failed to prepare comment batch delete statement")?;
-        let mut deleted = 0usize;
-        for id in ids {
-            deleted += stmt
-                .execute(params![id])
-                .with_context(|| format!("failed to batch delete comment {id}"))?;
-        }
-        drop(stmt);
-        tx.commit()
-            .context("failed to commit comment batch delete transaction")?;
-        Ok(deleted)
+        execute_many_comment_ids(
+            &mut conn,
+            sql::comments::DELETE_BY_ID,
+            ids,
+            "failed to start sqlite transaction for comment batch delete",
+            "failed to prepare comment batch delete statement",
+            "failed to commit comment batch delete transaction",
+            |stmt, id| {
+                stmt.execute(params![id])
+                    .with_context(|| format!("failed to batch delete comment {id}"))
+            },
+        )
     }
 
     pub fn prune_non_open_comments(&self, cutoff_unix_ms: i64) -> Result<usize> {
@@ -427,6 +410,42 @@ fn next_comment_id() -> String {
     format!("comment-{now_nanos:032x}-{pid:08x}-{counter:016x}")
 }
 
+fn execute_many_comment_ids<F>(
+    conn: &mut rusqlite::Connection,
+    sql: &str,
+    ids: &[String],
+    transaction_context: &'static str,
+    prepare_context: &'static str,
+    commit_context: &'static str,
+    mut execute: F,
+) -> Result<usize>
+where
+    F: FnMut(&mut rusqlite::Statement<'_>, &str) -> Result<usize>,
+{
+    let tx = conn.transaction().context(transaction_context)?;
+    let mut stmt = tx.prepare(sql).context(prepare_context)?;
+    let mut affected = 0usize;
+    for id in ids {
+        affected += execute(&mut stmt, id.as_str())?;
+    }
+    drop(stmt);
+    tx.commit().context(commit_context)?;
+    Ok(affected)
+}
+
+fn get_comment_with_connection(
+    conn: &rusqlite::Connection,
+    id: &str,
+) -> Result<Option<CommentRecord>> {
+    let mut stmt = conn
+        .prepare(sql::comments::SELECT_BY_ID)
+        .context("failed to prepare select comment by id query")?;
+
+    stmt.query_row(params![id], map_comment_row)
+        .optional()
+        .context("failed to query comment by id")
+}
+
 fn map_comment_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CommentRecord> {
     let status_raw: String = row.get("status")?;
     let line_side_raw: String = row.get("line_side")?;
@@ -441,7 +460,7 @@ fn map_comment_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CommentRecord> {
 
     let old_line = old_line_db.map(sql_i64_to_u32).transpose()?;
     let new_line = new_line_db.map(sql_i64_to_u32).transpose()?;
-    let row_stable_id = row_stable_id_db.map(|value| value as u64);
+    let row_stable_id = row_stable_id_db.map(sql_i64_to_u64).transpose()?;
 
     Ok(CommentRecord {
         id: row.get("id")?,
@@ -479,6 +498,24 @@ fn sql_i64_to_u32(value: i64) -> rusqlite::Result<u32> {
             )),
         )
     })
+}
+
+fn sql_i64_to_u64(value: i64) -> rusqlite::Result<u64> {
+    u64::try_from(value).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Integer,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("cannot convert sqlite integer {value} to u64"),
+            )),
+        )
+    })
+}
+
+fn sql_u64_to_i64(value: u64) -> Result<i64> {
+    i64::try_from(value)
+        .map_err(|_| anyhow!("cannot convert row_stable_id {value} to sqlite integer"))
 }
 
 fn invalid_text_value(column: &str, value: &str) -> rusqlite::Error {

--- a/crates/hunk-domain/src/db/connection.rs
+++ b/crates/hunk-domain/src/db/connection.rs
@@ -8,6 +8,24 @@ use super::sql;
 
 const DB_FILE_NAME: &str = "hunk.db";
 const DB_SCHEMA_VERSION: i64 = 2;
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        name: "0001_init.sql",
+        sql: include_str!("migrations/0001_init.sql"),
+    },
+    Migration {
+        version: 2,
+        name: "0002_branch_scope_reset.sql",
+        sql: include_str!("migrations/0002_branch_scope_reset.sql"),
+    },
+];
+
+struct Migration {
+    version: i64,
+    name: &'static str,
+    sql: &'static str,
+}
 
 #[derive(Debug, Clone)]
 pub struct DatabaseStore {
@@ -64,11 +82,20 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         ));
     }
 
-    if user_version < 2 {
-        conn.execute_batch(include_str!("migrations/0002_branch_scope_reset.sql"))
-            .context("failed to run migration 0002_branch_scope_reset.sql")?;
-        conn.pragma_update(None, "user_version", DB_SCHEMA_VERSION)
-            .context("failed to update sqlite user_version to schema version 2")?;
+    for migration in MIGRATIONS {
+        if user_version >= migration.version {
+            continue;
+        }
+
+        conn.execute_batch(migration.sql)
+            .with_context(|| format!("failed to run migration {}", migration.name))?;
+        conn.pragma_update(None, "user_version", migration.version)
+            .with_context(|| {
+                format!(
+                    "failed to update sqlite user_version to schema version {}",
+                    migration.version
+                )
+            })?;
     }
 
     Ok(())

--- a/crates/hunk-domain/src/db/migrations/0001_init.sql
+++ b/crates/hunk-domain/src/db/migrations/0001_init.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS comments (
   line_side TEXT NOT NULL CHECK (line_side IN ('left', 'right', 'meta')),
   old_line INTEGER,
   new_line INTEGER,
-  row_stable_id INTEGER,
+  row_stable_id INTEGER CHECK (row_stable_id IS NULL OR row_stable_id >= 0),
   hunk_header TEXT,
 
   line_text TEXT NOT NULL,

--- a/crates/hunk-domain/src/db/migrations/0002_branch_scope_reset.sql
+++ b/crates/hunk-domain/src/db/migrations/0002_branch_scope_reset.sql
@@ -12,7 +12,7 @@ CREATE TABLE comments (
   line_side TEXT NOT NULL CHECK (line_side IN ('left', 'right', 'meta')),
   old_line INTEGER,
   new_line INTEGER,
-  row_stable_id INTEGER,
+  row_stable_id INTEGER CHECK (row_stable_id IS NULL OR row_stable_id >= 0),
   hunk_header TEXT,
 
   line_text TEXT NOT NULL,

--- a/crates/hunk-domain/src/markdown_preview.rs
+++ b/crates/hunk-domain/src/markdown_preview.rs
@@ -308,53 +308,38 @@ fn parse_inline_node(
     match node {
         Node::Text(text) => push_inline_span(out, text.value.as_str(), style),
         Node::InlineCode(code) => {
-            let mut next_style = style.clone();
-            next_style.code = true;
+            let next_style = updated_inline_style(style, |next| next.code = true);
             push_inline_span(out, code.value.as_str(), &next_style);
         }
         Node::InlineMath(math) => {
-            let mut next_style = style.clone();
-            next_style.code = true;
+            let next_style = updated_inline_style(style, |next| next.code = true);
             push_inline_span(out, math.value.as_str(), &next_style);
         }
         Node::Emphasis(node) => {
-            let mut next_style = style.clone();
-            next_style.italic = true;
-            for child in &node.children {
-                parse_inline_node(child, &next_style, references, out);
-            }
+            let next_style = updated_inline_style(style, |next| next.italic = true);
+            push_inline_children(&node.children, &next_style, references, out);
         }
         Node::Strong(node) => {
-            let mut next_style = style.clone();
-            next_style.bold = true;
-            for child in &node.children {
-                parse_inline_node(child, &next_style, references, out);
-            }
+            let next_style = updated_inline_style(style, |next| next.bold = true);
+            push_inline_children(&node.children, &next_style, references, out);
         }
         Node::Delete(node) => {
-            let mut next_style = style.clone();
-            next_style.strikethrough = true;
-            for child in &node.children {
-                parse_inline_node(child, &next_style, references, out);
-            }
+            let next_style = updated_inline_style(style, |next| next.strikethrough = true);
+            push_inline_children(&node.children, &next_style, references, out);
         }
         Node::Link(link) => {
-            let mut next_style = style.clone();
-            next_style.link = Some(link.url.clone());
-            for child in &link.children {
-                parse_inline_node(child, &next_style, references, out);
-            }
+            let next_style = updated_inline_style(style, |next| next.link = Some(link.url.clone()));
+            push_inline_children(&link.children, &next_style, references, out);
         }
         Node::LinkReference(link_reference) => {
-            let mut next_style = style.clone();
-            next_style.link = references.resolve_link(link_reference.identifier.as_str());
-            for child in &link_reference.children {
-                parse_inline_node(child, &next_style, references, out);
-            }
+            let next_style = updated_inline_style(style, |next| {
+                next.link = references.resolve_link(link_reference.identifier.as_str())
+            });
+            push_inline_children(&link_reference.children, &next_style, references, out);
         }
         Node::Image(image) => {
-            let mut next_style = style.clone();
-            next_style.link = Some(image.url.clone());
+            let next_style =
+                updated_inline_style(style, |next| next.link = Some(image.url.clone()));
             let label = if image.alt.is_empty() {
                 "image"
             } else {
@@ -363,8 +348,9 @@ fn parse_inline_node(
             push_inline_span(out, format!("[{label}]").as_str(), &next_style);
         }
         Node::ImageReference(image_reference) => {
-            let mut next_style = style.clone();
-            next_style.link = references.resolve_link(image_reference.identifier.as_str());
+            let next_style = updated_inline_style(style, |next| {
+                next.link = references.resolve_link(image_reference.identifier.as_str())
+            });
             let label = if image_reference.alt.is_empty() {
                 "image"
             } else {
@@ -397,6 +383,26 @@ fn parse_inline_node(
     }
 }
 
+fn updated_inline_style(
+    style: &MarkdownInlineStyle,
+    update: impl FnOnce(&mut MarkdownInlineStyle),
+) -> MarkdownInlineStyle {
+    let mut next_style = style.clone();
+    update(&mut next_style);
+    next_style
+}
+
+fn push_inline_children(
+    children: &[Node],
+    style: &MarkdownInlineStyle,
+    references: &MarkdownReferences,
+    out: &mut Vec<MarkdownInlineSpan>,
+) {
+    for child in children {
+        parse_inline_node(child, style, references, out);
+    }
+}
+
 fn push_inline_span(out: &mut Vec<MarkdownInlineSpan>, text: &str, style: &MarkdownInlineStyle) {
     if text.is_empty() {
         return;
@@ -416,8 +422,7 @@ fn push_inline_span(out: &mut Vec<MarkdownInlineSpan>, text: &str, style: &Markd
 }
 
 fn push_hard_break_span(out: &mut Vec<MarkdownInlineSpan>, style: &MarkdownInlineStyle) {
-    let mut next_style = style.clone();
-    next_style.hard_break = true;
+    let next_style = updated_inline_style(style, |next| next.hard_break = true);
     out.push(MarkdownInlineSpan {
         text: String::new(),
         style: next_style,

--- a/crates/hunk-domain/tests/db_comments_store.rs
+++ b/crates/hunk-domain/tests/db_comments_store.rs
@@ -6,6 +6,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use hunk_domain::db::{CommentLineSide, CommentStatus, DatabaseStore, NewComment};
 use rusqlite::Connection;
 
+const MIGRATION_0001_INIT: &str = include_str!("../src/db/migrations/0001_init.sql");
+
 struct TempDb {
     path: PathBuf,
     store: DatabaseStore,
@@ -214,6 +216,66 @@ fn touch_and_delete_comment_work() {
 }
 
 #[test]
+fn batch_comment_updates_apply_to_each_requested_id() {
+    let fixture = TempDb::new("comments-batch-updates");
+    let first = fixture
+        .store
+        .create_comment(&new_comment("/repo", "main", "src/one.rs", "first"))
+        .expect("create first comment");
+    let second = fixture
+        .store
+        .create_comment(&new_comment("/repo", "main", "src/two.rs", "second"))
+        .expect("create second comment");
+    let third = fixture
+        .store
+        .create_comment(&new_comment("/repo", "main", "src/three.rs", "third"))
+        .expect("create third comment");
+
+    let touched = fixture
+        .store
+        .touch_many_comment_seen(&[first.id.clone(), second.id.clone()], 2222)
+        .expect("touch many comments");
+    assert_eq!(touched, 2);
+
+    let marked = fixture
+        .store
+        .mark_many_comment_status(
+            &[first.id.clone(), second.id.clone()],
+            CommentStatus::Stale,
+            Some("anchor_not_found"),
+            3333,
+        )
+        .expect("mark many comments stale");
+    assert_eq!(marked, 2);
+
+    let deleted = fixture
+        .store
+        .delete_many_comments(std::slice::from_ref(&third.id))
+        .expect("delete many comments");
+    assert_eq!(deleted, 1);
+
+    let comments = fixture
+        .store
+        .list_comments("/repo", "main", true)
+        .expect("list comments after batch updates");
+    assert_eq!(comments.len(), 2);
+    assert!(
+        comments
+            .iter()
+            .all(|comment| comment.status == CommentStatus::Stale)
+    );
+    assert!(
+        comments
+            .iter()
+            .all(|comment| comment.last_seen_at_unix_ms == Some(2222))
+    );
+    assert!(comments.iter().all(|comment| {
+        comment.stale_reason.as_deref() == Some("anchor_not_found")
+            && comment.updated_at_unix_ms == 3333
+    }));
+}
+
+#[test]
 fn create_comment_ids_are_unique_within_process() {
     let fixture = TempDb::new("comments-id-unique");
     let mut ids = HashSet::new();
@@ -233,4 +295,154 @@ fn create_comment_ids_are_unique_within_process() {
             "duplicate comment id should never be generated"
         );
     }
+}
+
+#[test]
+fn create_comment_rejects_row_stable_id_larger_than_i64_max() {
+    let fixture = TempDb::new("comments-row-stable-id-overflow");
+    let mut comment = new_comment("/repo", "main", "src/lib.rs", "overflow");
+    comment.row_stable_id = Some(i64::MAX as u64 + 1);
+
+    let err = fixture
+        .store
+        .create_comment(&comment)
+        .expect_err("oversized row_stable_id should be rejected");
+
+    assert!(err.to_string().contains("cannot convert row_stable_id"));
+}
+
+#[test]
+fn sqlite_schema_rejects_negative_row_stable_id() {
+    let fixture = TempDb::new("comments-row-stable-id-negative");
+    fixture
+        .store
+        .list_comments("/repo", "main", true)
+        .expect("listing comments should initialize db");
+
+    let conn = Connection::open(&fixture.path).expect("open sqlite db");
+    let err = conn
+        .execute(
+            "INSERT INTO comments (
+                id,
+                repo_root,
+                branch_name,
+                created_head_commit,
+                status,
+                file_path,
+                line_side,
+                old_line,
+                new_line,
+                row_stable_id,
+                hunk_header,
+                line_text,
+                context_before,
+                context_after,
+                anchor_hash,
+                comment_text,
+                stale_reason,
+                created_at_unix_ms,
+                updated_at_unix_ms,
+                last_seen_at_unix_ms,
+                resolved_at_unix_ms
+            ) VALUES (
+                'comment-negative-row-stable-id',
+                '/repo',
+                'main',
+                'abc123',
+                'open',
+                'src/lib.rs',
+                'right',
+                10,
+                11,
+                -1,
+                '@@ -10,3 +11,4 @@',
+                'let value = 1;',
+                ' let other = 0;',
+                '+let value = 1;',
+                'anchor-hash-negative',
+                'negative row stable id',
+                NULL,
+                1,
+                1,
+                1,
+                NULL
+            )",
+            [],
+        )
+        .expect_err("negative row_stable_id should violate the schema constraint");
+
+    assert!(err.to_string().contains("row_stable_id"));
+}
+
+#[test]
+fn upgrading_a_version_1_database_runs_ordered_migrations() {
+    let fixture = TempDb::new("comments-version-1-upgrade");
+
+    let conn = Connection::open(&fixture.path).expect("open sqlite db");
+    conn.execute_batch(MIGRATION_0001_INIT)
+        .expect("apply version 1 schema");
+    conn.pragma_update(None, "user_version", 1_i64)
+        .expect("set sqlite user_version to 1");
+    conn.execute(
+        "INSERT INTO comments (
+            id,
+            repo_root,
+            branch_name,
+            created_head_commit,
+            status,
+            file_path,
+            line_side,
+            old_line,
+            new_line,
+            row_stable_id,
+            hunk_header,
+            line_text,
+            context_before,
+            context_after,
+            anchor_hash,
+            comment_text,
+            stale_reason,
+            created_at_unix_ms,
+            updated_at_unix_ms,
+            last_seen_at_unix_ms,
+            resolved_at_unix_ms
+        ) VALUES (
+            'comment-version-1',
+            '/repo',
+            'main',
+            'abc123',
+            'open',
+            'src/lib.rs',
+            'right',
+            10,
+            11,
+            42,
+            '@@ -10,3 +11,4 @@',
+            'let value = 1;',
+            ' let other = 0;',
+            '+let value = 1;',
+            'anchor-hash-version-1',
+            'legacy comment',
+            NULL,
+            1,
+            1,
+            1,
+            NULL
+        )",
+        [],
+    )
+    .expect("insert legacy version 1 comment");
+    drop(conn);
+
+    let comments = fixture
+        .store
+        .list_comments("/repo", "main", true)
+        .expect("upgrade version 1 database");
+    assert!(comments.is_empty());
+
+    let conn = Connection::open(&fixture.path).expect("reopen upgraded sqlite db");
+    let user_version: i64 = conn
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .expect("read upgraded sqlite user_version");
+    assert_eq!(user_version, 2);
 }


### PR DESCRIPTION
Validate `row_stable_id` conversions end-to-end (Rust + SQLite constraints), reuse a single connection for insert/readback, and consolidate repeated batch comment update/delete transaction logic. Replace version-specific migration branching with ordered migration application, and add regression tests for overflow, negative IDs, batch updates, and v1->v2 upgrade behavior.