### PR TITLE
Add fmt and 3-platform clippy checks before CI builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -51,10 +51,12 @@ jobs:
         run: cargo fmt --all --check
         shell: bash
 
-  clippy:
-    name: Clippy
+  linux:
+    name: Linux
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - fmt
 
     steps:
       - name: Checkout
@@ -74,7 +76,7 @@ jobs:
       - name: Cache cargo registry and Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: pr-build-linux-desktop
+          shared-key: pr-build-${{ runner.os }}-desktop
           workspaces: |
             . -> target-shared
           cache-on-failure: "true"
@@ -103,21 +105,20 @@ jobs:
         run: cargo clippy -p hunk-desktop --locked --profile ci --no-deps -- -D warnings
         shell: bash
 
+      - name: Build hunk-desktop
+        run: cargo build -p hunk-desktop --locked --profile ci
+        shell: bash
+
   build:
     name: ${{ matrix.name }}
     needs:
       - fmt
-      - clippy
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Linux
-            os: ubuntu-latest
-            resolve_target_dir: |
-              echo "CARGO_TARGET_DIR=$(./scripts/resolve_cargo_target_dir.sh "$GITHUB_WORKSPACE")" >> "$GITHUB_ENV"
           - name: macOS
             os: macos-latest
             resolve_target_dir: |
@@ -154,27 +155,6 @@ jobs:
           workspaces: |
             . -> target-shared
           cache-on-failure: "true"
-
-      - name: Install Linux build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            clang \
-            cmake \
-            libasound2-dev \
-            libfontconfig-dev \
-            libgit2-dev \
-            libglib2.0-dev \
-            libssl-dev \
-            libvulkan1 \
-            libwayland-dev \
-            libx11-xcb-dev \
-            libxkbcommon-x11-dev \
-            libzstd-dev \
-            pkg-config
-        shell: bash
 
       - name: Build hunk-desktop
         if: runner.os != 'Windows'


### PR DESCRIPTION
Introduce separate `fmt` and matrix `clippy` jobs (Linux, macOS, Windows) and make `build` depend on both. Clippy uses `--no-deps` with the existing CI profile and shared target-dir resolution on each OS to keep the pre-build check fast and consistent.