### PR TITLE
Add AI thread-selection diagnostics across workspace/runtime paths

### DIFF
--- a/crates/hunk-desktop/src/app/ai_runtime/core.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/core.rs
@@ -521,12 +521,6 @@ impl AiWorkerRuntime {
                 }
             }
             AiWorkerCommand::SelectThread { thread_id } => {
-                tracing::debug!(
-                    workspace_key = self.workspace_key.as_str(),
-                    thread_id = thread_id.as_str(),
-                    active_thread_id = ?self.service.active_thread_for_workspace(),
-                    "AI worker received SelectThread command"
-                );
                 self.load_thread_snapshot(thread_id)?;
                 self.emit_snapshot_after_sync(event_tx)?;
             }
@@ -772,12 +766,6 @@ impl AiWorkerRuntime {
         thread_id: String,
     ) -> Result<(), CodexIntegrationError> {
         let read_thread_id = thread_id.clone();
-        tracing::debug!(
-            workspace_key = self.workspace_key.as_str(),
-            thread_id = read_thread_id.as_str(),
-            active_thread_id = ?self.service.active_thread_for_workspace(),
-            "Starting AI thread snapshot load"
-        );
         match retry_transient_rollout_load(
             TRANSIENT_ROLLOUT_LOAD_MAX_RETRIES,
             TRANSIENT_ROLLOUT_LOAD_RETRY_DELAY,
@@ -814,12 +802,6 @@ impl AiWorkerRuntime {
             Err(error) => return Err(error),
         }
         self.hydrate_thread_from_rollout_fallback_if_needed(read_thread_id.as_str());
-        tracing::debug!(
-            workspace_key = self.workspace_key.as_str(),
-            thread_id = read_thread_id.as_str(),
-            active_thread_id = ?self.service.active_thread_for_workspace(),
-            "Finished AI thread snapshot load"
-        );
         Ok(())
     }
 

--- a/crates/hunk-desktop/src/app/controller/ai/catalog.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/catalog.rs
@@ -101,17 +101,7 @@ impl DiffViewer {
                 .unwrap_or_else(|| {
                     self.default_ai_workspace_state_for_workspace_key(Some(workspace_key.as_str()))
                 });
-            let previous_selected_thread_id = state.selected_thread_id.clone();
             apply_ai_thread_catalog_to_workspace_state(&mut state, catalog);
-            if previous_selected_thread_id != state.selected_thread_id {
-                tracing::debug!(
-                    workspace_key = workspace_key.as_str(),
-                    previous_selected_thread_id = ?previous_selected_thread_id.as_deref(),
-                    next_selected_thread_id = ?state.selected_thread_id.as_deref(),
-                    snapshot_thread_count = state.state_snapshot.threads.len(),
-                    "AI thread catalog changed background workspace selection"
-                );
-            }
             self.ai_workspace_states.insert(workspace_key, state);
         }
     }

--- a/crates/hunk-desktop/src/app/controller/ai/core_actions.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/core_actions.rs
@@ -30,13 +30,6 @@ impl DiffViewer {
             return;
         };
         let worker_workspace_key = cwd.to_string_lossy().to_string();
-        tracing::debug!(
-            requested_workspace_key = worker_workspace_key.as_str(),
-            requested_workspace_key_override = ?workspace_key,
-            visible_worker_workspace_key = ?self.ai_worker_workspace_key.as_deref(),
-            selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-            "Ensuring AI runtime is started"
-        );
         if self.ai_command_tx.is_some()
             && self.ai_worker_workspace_key.as_deref() == Some(worker_workspace_key.as_str())
         {
@@ -52,12 +45,6 @@ impl DiffViewer {
         self.sync_ai_workspace_preferences_from_state();
 
         if self.promote_hidden_ai_runtime(worker_workspace_key.as_str()) {
-            tracing::debug!(
-                workspace_key = worker_workspace_key.as_str(),
-                selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-                "Promoted hidden AI runtime instead of starting a new one"
-            );
-            self.log_ai_thread_selection_resolution("ensure_ai_runtime_started:promote-hidden");
             cx.notify();
             return;
         }
@@ -96,11 +83,6 @@ impl DiffViewer {
         self.ai_worker_workspace_key = Some(worker_workspace_key);
 
         let epoch = self.next_ai_event_epoch();
-        tracing::debug!(
-            workspace_key = listener_workspace_key.as_str(),
-            generation = epoch,
-            "Started new AI runtime and event listener"
-        );
         self.start_ai_event_listener(event_rx, listener_workspace_key, epoch, cx);
         cx.notify();
     }
@@ -535,14 +517,6 @@ impl DiffViewer {
             .ai_thread_workspace_root(thread_id.as_str())
             .map(|root| root.to_string_lossy().to_string())
             .or_else(|| previous_workspace_key.clone());
-        tracing::debug!(
-            thread_id = thread_id.as_str(),
-            previous_workspace_key = ?previous_workspace_key.as_deref(),
-            next_workspace_key = ?next_workspace_key.as_deref(),
-            visible_worker_workspace_key = ?self.ai_worker_workspace_key.as_deref(),
-            previously_selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-            "Selecting AI thread from sidebar"
-        );
         let previous_draft_key = self.current_ai_composer_draft_key();
         self.sync_ai_visible_composer_prompt_to_draft(cx);
         self.ai_handle_workspace_change_to(previous_workspace_key, next_workspace_key, cx);
@@ -560,7 +534,6 @@ impl DiffViewer {
         reset_ai_timeline_list_measurements(self, visible_row_ids.len());
         self.flush_ai_timeline_scroll_request();
         self.sync_ai_session_selection_from_state();
-        self.log_ai_thread_selection_resolution("ai_select_thread:before-command");
         self.send_ai_worker_command(AiWorkerCommand::SelectThread { thread_id }, cx);
         cx.notify();
     }

--- a/crates/hunk-desktop/src/app/controller/ai/core_workspace.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/core_workspace.rs
@@ -17,44 +17,6 @@ impl DiffViewer {
         )
     }
 
-    fn log_ai_thread_selection_resolution(&self, context: &str) {
-        let raw_selected_thread_id = self.ai_selected_thread_id.clone();
-        let raw_selected_workspace_key = raw_selected_thread_id
-            .as_deref()
-            .and_then(|thread_id| self.ai_thread_workspace_root(thread_id))
-            .map(|path| path.to_string_lossy().to_string());
-        let fallback_workspace_key = current_visible_thread_fallback_workspace_key(
-            self.ai_worker_workspace_key.as_deref(),
-            raw_selected_workspace_key
-                .as_deref()
-                .map(std::path::Path::new),
-            self.ai_workspace_key_for_draft().as_deref(),
-        );
-        let resolved_thread_id = self.current_ai_thread_id();
-        let resolved_workspace_key = resolved_thread_id
-            .as_deref()
-            .and_then(|thread_id| self.ai_thread_workspace_root(thread_id))
-            .map(|path| path.to_string_lossy().to_string());
-
-        if raw_selected_thread_id != resolved_thread_id {
-            tracing::debug!(
-                context,
-                raw_selected_thread_id = ?raw_selected_thread_id.as_deref(),
-                raw_selected_workspace_key = ?raw_selected_workspace_key.as_deref(),
-                resolved_thread_id = ?resolved_thread_id.as_deref(),
-                resolved_workspace_key = ?resolved_workspace_key.as_deref(),
-                visible_worker_workspace_key = ?self.ai_worker_workspace_key.as_deref(),
-                fallback_workspace_key = ?fallback_workspace_key.as_deref(),
-                new_thread_draft_active = self.ai_new_thread_draft_active,
-                pending_new_thread_selection = self.ai_pending_new_thread_selection,
-                visible_snapshot_thread_count = self.ai_state_snapshot.threads.len(),
-                background_workspace_state_count = self.ai_workspace_states.len(),
-                hidden_runtime_count = self.ai_hidden_runtimes.len(),
-                "AI selected thread resolved to a different effective thread"
-            );
-        }
-    }
-
     pub(crate) fn ai_pending_thread_start_for_timeline(&self) -> Option<AiPendingThreadStart> {
         let pending = self.ai_pending_thread_start.clone()?;
         if self.ai_workspace_key().as_deref() != Some(pending.workspace_key.as_str()) {
@@ -462,8 +424,6 @@ impl DiffViewer {
     }
 
     fn apply_ai_workspace_state(&mut self, state: AiWorkspaceState) {
-        let incoming_selected_thread_id = state.selected_thread_id.clone();
-        let incoming_snapshot_thread_count = state.state_snapshot.threads.len();
         self.ai_connection_state = state.connection_state;
         self.ai_bootstrap_loading = state.bootstrap_loading;
         self.ai_status_message = state.status_message;
@@ -540,29 +500,12 @@ impl DiffViewer {
         self.prune_ai_composer_drafts();
         self.prune_ai_composer_statuses();
         reset_ai_timeline_list_measurements(self, 0);
-        tracing::debug!(
-            incoming_selected_thread_id = ?incoming_selected_thread_id.as_deref(),
-            applied_selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-            visible_worker_workspace_key = ?self.ai_worker_workspace_key.as_deref(),
-            visible_snapshot_thread_count = incoming_snapshot_thread_count,
-            pending_new_thread_selection = self.ai_pending_new_thread_selection,
-            new_thread_draft_active = self.ai_new_thread_draft_active,
-            "Applied AI workspace state"
-        );
-        self.log_ai_thread_selection_resolution("apply_ai_workspace_state");
     }
 
     fn store_current_ai_workspace_state(&mut self, workspace_key: Option<&str>) {
         let Some(workspace_key) = workspace_key else {
             return;
         };
-        tracing::debug!(
-            workspace_key,
-            selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-            visible_snapshot_thread_count = self.ai_state_snapshot.threads.len(),
-            visible_worker_workspace_key = ?self.ai_worker_workspace_key.as_deref(),
-            "Stored current AI workspace state"
-        );
         self.ai_workspace_states.insert(
             workspace_key.to_string(),
             self.capture_current_ai_workspace_state(),
@@ -573,14 +516,6 @@ impl DiffViewer {
         let state = workspace_key
             .and_then(|key| self.ai_workspace_states.get(key).cloned())
             .unwrap_or_else(|| self.default_ai_workspace_state_for_workspace_key(workspace_key));
-        tracing::debug!(
-            requested_workspace_key = ?workspace_key,
-            restored_selected_thread_id = ?state.selected_thread_id.as_deref(),
-            restored_snapshot_thread_count = state.state_snapshot.threads.len(),
-            restored_pending_new_thread_selection = state.pending_new_thread_selection,
-            restored_new_thread_draft_active = state.new_thread_draft_active,
-            "Restoring AI workspace state"
-        );
         self.apply_ai_workspace_state(state);
     }
 
@@ -596,12 +531,6 @@ impl DiffViewer {
             self.ai_worker_workspace_key = None;
             return;
         };
-        tracing::debug!(
-            workspace_key,
-            generation = self.ai_event_epoch,
-            selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-            "Parking visible AI runtime"
-        );
         let event_task = std::mem::replace(&mut self.ai_event_task, Task::ready(()));
         self.ai_hidden_runtimes.insert(
             workspace_key,
@@ -627,12 +556,6 @@ impl DiffViewer {
             }
             return false;
         }
-        tracing::debug!(
-            workspace_key,
-            generation = handle.generation,
-            hidden_runtime_count_after_remove = self.ai_hidden_runtimes.len(),
-            "Promoting hidden AI runtime"
-        );
         self.ai_command_tx = Some(handle.command_tx);
         self.ai_worker_thread = Some(handle.worker_thread);
         self.ai_event_task = handle.event_task;
@@ -802,45 +725,32 @@ impl DiffViewer {
         workspace_key: &str,
         event: AiWorkerEventPayload,
     ) {
-        self.update_background_ai_workspace_state(workspace_key, |state| {
-            let previous_selected_thread_id = state.selected_thread_id.clone();
-            match event {
-                AiWorkerEventPayload::Snapshot(snapshot) => {
-                    Self::apply_ai_snapshot_to_workspace_state(state, *snapshot);
-                }
-                AiWorkerEventPayload::BootstrapCompleted => {
-                    state.bootstrap_loading = false;
-                }
-                AiWorkerEventPayload::ThreadStarted { thread_id } => {
-                    set_pending_thread_start_thread_id(&mut state.pending_thread_start, thread_id);
-                }
-                AiWorkerEventPayload::Reconnecting(message) => {
-                    state.connection_state = AiConnectionState::Reconnecting;
-                    state.bootstrap_loading = false;
-                    state.error_message = None;
-                    state.status_message = Some(message);
-                }
-                AiWorkerEventPayload::Status(message) => {
-                    state.status_message = Some(message);
-                }
-                AiWorkerEventPayload::Error(message) => {
-                    Self::restore_ai_workspace_state_after_failure_for_state(state);
-                    state.error_message = Some(message.clone());
-                    state.status_message = Some(message);
-                }
-                AiWorkerEventPayload::Fatal(message) => {
-                    Self::apply_background_ai_workspace_fatal(state, message);
-                }
+        self.update_background_ai_workspace_state(workspace_key, |state| match event {
+            AiWorkerEventPayload::Snapshot(snapshot) => {
+                Self::apply_ai_snapshot_to_workspace_state(state, *snapshot);
             }
-
-            if previous_selected_thread_id != state.selected_thread_id {
-                tracing::debug!(
-                    workspace_key,
-                    previous_selected_thread_id = ?previous_selected_thread_id.as_deref(),
-                    next_selected_thread_id = ?state.selected_thread_id.as_deref(),
-                    snapshot_thread_count = state.state_snapshot.threads.len(),
-                    "Background AI workspace selection changed"
-                );
+            AiWorkerEventPayload::BootstrapCompleted => {
+                state.bootstrap_loading = false;
+            }
+            AiWorkerEventPayload::ThreadStarted { thread_id } => {
+                set_pending_thread_start_thread_id(&mut state.pending_thread_start, thread_id);
+            }
+            AiWorkerEventPayload::Reconnecting(message) => {
+                state.connection_state = AiConnectionState::Reconnecting;
+                state.bootstrap_loading = false;
+                state.error_message = None;
+                state.status_message = Some(message);
+            }
+            AiWorkerEventPayload::Status(message) => {
+                state.status_message = Some(message);
+            }
+            AiWorkerEventPayload::Error(message) => {
+                Self::restore_ai_workspace_state_after_failure_for_state(state);
+                state.error_message = Some(message.clone());
+                state.status_message = Some(message);
+            }
+            AiWorkerEventPayload::Fatal(message) => {
+                Self::apply_background_ai_workspace_fatal(state, message);
             }
         });
     }

--- a/crates/hunk-desktop/src/app/controller/ai/runtime.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime.rs
@@ -73,12 +73,6 @@ impl DiffViewer {
             active_thread_id.as_deref(),
             &self.ai_state_snapshot,
         ) {
-            tracing::debug!(
-                thread_id = thread_id.as_str(),
-                active_thread_id = ?active_thread_id.as_deref(),
-                previous_selected_thread_id = ?previous_selected_thread.as_deref(),
-                "Selecting AI thread because pending new thread became ready"
-            );
             self.ai_new_thread_draft_active = false;
             self.ai_pending_new_thread_selection = false;
             self.ai_selected_thread_id = Some(thread_id);
@@ -90,11 +84,6 @@ impl DiffViewer {
             self.ai_new_thread_draft_active || self.ai_pending_new_thread_selection,
             &self.ai_state_snapshot,
         ) {
-            tracing::debug!(
-                previous_selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-                next_selected_thread_id = ?active_thread_id.as_deref(),
-                "Syncing AI selected thread from active thread"
-            );
             self.ai_selected_thread_id = active_thread_id.clone();
         }
 
@@ -104,10 +93,6 @@ impl DiffViewer {
                 .get(selected)
                 .is_none_or(|thread| thread.status == ThreadLifecycleStatus::Archived)
         }) {
-            tracing::debug!(
-                selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-                "Clearing AI selected thread because it is missing or archived in visible snapshot"
-            );
             self.ai_selected_thread_id = None;
         }
 
@@ -116,10 +101,6 @@ impl DiffViewer {
             && self.ai_selected_thread_id.is_none()
         {
             self.ai_selected_thread_id = self.current_ai_thread_id();
-            tracing::debug!(
-                next_selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-                "Rehydrated AI selected thread from current visible snapshot state"
-            );
         }
 
         if !self.ai_new_thread_draft_active
@@ -128,10 +109,6 @@ impl DiffViewer {
             && let Some(first_thread) = self.ai_threads_for_current_workspace().first()
         {
             self.ai_selected_thread_id = Some(first_thread.id.clone());
-            tracing::debug!(
-                next_selected_thread_id = first_thread.id.as_str(),
-                "Fell back to first AI thread in current workspace"
-            );
         }
         if self.ai_pending_thread_start.as_ref().is_some_and(|pending| {
             pending.thread_id.as_ref().is_some_and(|thread_id| {
@@ -197,17 +174,6 @@ impl DiffViewer {
         if previous_draft_key != self.current_ai_composer_draft_key() {
             self.restore_ai_visible_composer_from_current_draft(cx);
         }
-        if previous_selected_thread != self.ai_selected_thread_id {
-            tracing::debug!(
-                previous_selected_thread_id = ?previous_selected_thread.as_deref(),
-                next_selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-                active_thread_id = ?active_thread_id.as_deref(),
-                visible_worker_workspace_key = ?self.ai_worker_workspace_key.as_deref(),
-                visible_snapshot_thread_count = self.ai_state_snapshot.threads.len(),
-                "AI selected thread changed while applying snapshot"
-            );
-        }
-        self.log_ai_thread_selection_resolution("apply_ai_snapshot");
         self.maybe_refresh_selected_thread_metadata(cx);
         self.sync_ai_session_selection_from_state();
     }

--- a/crates/hunk-desktop/src/app/controller/ai/runtime_events.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime_events.rs
@@ -19,14 +19,6 @@ impl DiffViewer {
                             if !this
                                 .ai_runtime_listener_is_current(workspace_key.as_str(), generation)
                             {
-                                tracing::debug!(
-                                    workspace_key = workspace_key.as_str(),
-                                    generation,
-                                    visible_worker_workspace_key = ?this.ai_worker_workspace_key.as_deref(),
-                                    hidden_runtime_generation =
-                                        ?this.ai_runtime_listener_generation(workspace_key.as_str()),
-                                    "Stopping idle AI event listener because it is no longer current"
-                                );
                                 listener_is_current = false;
                                 return;
                             }
@@ -61,15 +53,6 @@ impl DiffViewer {
                         if !this
                             .ai_runtime_listener_is_current(workspace_key.as_str(), generation)
                         {
-                            tracing::debug!(
-                                workspace_key = workspace_key.as_str(),
-                                generation,
-                                visible_worker_workspace_key = ?this.ai_worker_workspace_key.as_deref(),
-                                hidden_runtime_generation =
-                                    ?this.ai_runtime_listener_generation(workspace_key.as_str()),
-                                buffered_event_count = buffered_events.len(),
-                                "Stopping AI event listener because it is no longer current"
-                            );
                             listener_is_current = false;
                             return;
                         }

--- a/crates/hunk-desktop/src/app/controller/ai/workspace_runtime.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/workspace_runtime.rs
@@ -14,16 +14,8 @@ impl DiffViewer {
         next_workspace_key: Option<String>,
         cx: &mut Context<Self>,
     ) {
-        tracing::debug!(
-            previous_workspace_key = ?previous_workspace_key.as_deref(),
-            next_workspace_key = ?next_workspace_key.as_deref(),
-            selected_thread_id = ?self.ai_selected_thread_id.as_deref(),
-            visible_worker_workspace_key = ?self.ai_worker_workspace_key.as_deref(),
-            "Handling AI workspace change"
-        );
         if previous_workspace_key == next_workspace_key {
             self.ai_sync_workspace_preferences(cx);
-            self.log_ai_thread_selection_resolution("ai_handle_workspace_change_to:no-op");
             return;
         }
 
@@ -38,6 +30,5 @@ impl DiffViewer {
             self.ensure_ai_runtime_started_for_workspace_key(next_workspace_key.as_deref(), cx);
         }
         self.ai_sync_workspace_preferences(cx);
-        self.log_ai_thread_selection_resolution("ai_handle_workspace_change_to");
     }
 }


### PR DESCRIPTION
Log raw vs effective selected thread resolution and selection changes during sidebar selects, snapshot applies, workspace swaps, hidden-runtime promotion, background state updates, and worker SelectThread loads. This targets intermittent cross-workspace thread jumps that self-resolve after rollout/snapshot hydration.