### PR TITLE
Normalize Windows target dir path for CI cache reuse

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -29,7 +29,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
-  # Keep PR CI behavior unchanged while allowing cache reuse checks on follow-up pushes.
 
 jobs:
   fmt:


### PR DESCRIPTION
Convert resolved target paths to native Windows form on msys/cygwin (via cygpath -w) so Cargo uses the same directory restored by GitHub Actions cache instead of rebuilding from scratch.