### PR TITLE
Bump Codex deps to rust-v0.115.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,8 +1092,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "anyhow",
  "clap",
@@ -1116,8 +1116,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "anyhow",
  "clap",
@@ -1132,8 +1132,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1142,8 +1142,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "once_cell",
  "regex",
@@ -1157,8 +1157,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "codex-execpolicy",
  "codex-git",
@@ -1182,8 +1182,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "dirs 6.0.0",
  "path-absolutize",
@@ -1194,8 +1194,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "lru",
  "sha1",
@@ -1204,8 +1204,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.113.0-alpha.2"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.113.0-alpha.2#3b24e175fd4f8be042b63dd61575b2ee4498a13d"
+version = "0.115.0-alpha.2"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0-alpha.2#f6a8a66ec96519b05a07ba635de7c0ad999a6883"
 dependencies = [
  "base64",
  "codex-utils-cache",
@@ -4362,7 +4362,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -10023,7 +10023,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/hunk-codex/Cargo.toml
+++ b/crates/hunk-codex/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "2.0"
 tracing = "0.1"
 url = "2.5"
 tungstenite = "0.28"
-codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.113.0-alpha.2" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.115.0-alpha.2" }
 
 [dev-dependencies]
 tempfile = "3.23"

--- a/crates/hunk-desktop/Cargo.toml
+++ b/crates/hunk-desktop/Cargo.toml
@@ -38,8 +38,8 @@ time = { version = "0.3", features = ["formatting", "local-offset"] }
 hunk-domain = { path = "../hunk-domain" }
 hunk-git = { path = "../hunk-git" }
 hunk-codex = { path = "../hunk-codex" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.113.0-alpha.2" }
-codex-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.113.0-alpha.2" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.115.0-alpha.2" }
+codex-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.115.0-alpha.2" }
 
 [dev-dependencies]
 git2 = { version = "0.20", features = ["https", "ssh"] }

--- a/docs/AI_CODEX_SPEC.md
+++ b/docs/AI_CODEX_SPEC.md
@@ -3,7 +3,7 @@
 ## Status
 - In progress
 - Owner: Hunk
-- Last Updated: 2026-03-09
+- Last Updated: 2026-03-10
 
 ## Product Decisions (Locked)
 1. Transport is WebSocket-only. Hunk will not implement a stdio integration path.
@@ -17,10 +17,10 @@
 
 ## Pinned Upstream Baseline
 - Codex repo: `https://github.com/openai/codex`
-- Pinned tag: `rust-v0.113.0-alpha.2`
-- Pinned commit SHA: `3b24e175fd4f8be042b63dd61575b2ee4498a13d`
-- Commit authored date (UTC): `2026-03-09T21:14:41Z`
-- Pin captured on: 2026-03-09
+- Pinned tag: `rust-v0.115.0-alpha.2`
+- Pinned commit SHA: `f6a8a66ec96519b05a07ba635de7c0ad999a6883`
+- Commit authored date (UTC): `2026-03-11T01:49:59Z`
+- Pin captured on: 2026-03-10
 
 ## Architecture Boundary
 - New crate: `crates/hunk-codex`


### PR DESCRIPTION
Update hunk-codex/hunk-desktop Codex git tags and refresh AI_CODEX_SPEC to the new pinned SHA. Cargo.lock also picks up two transitive Windows dependency edge updates from the upstream Codex graph.