### PR TITLE
Bump Codex dependencies to rust-v0.115.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -175,7 +175,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -639,7 +639,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1119,8 +1119,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "anyhow",
  "clap",
@@ -1143,8 +1143,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,8 +1159,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1169,8 +1169,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "once_cell",
  "regex",
@@ -1184,8 +1184,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "codex-execpolicy",
  "codex-git",
@@ -1209,8 +1209,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "dirs 6.0.0",
  "path-absolutize",
@@ -1221,8 +1221,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "lru",
  "sha1",
@@ -1231,8 +1231,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.115.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.115.0#f028679abb30051cec2434e624cd99975986b41b"
 dependencies = [
  "base64",
  "codex-utils-cache",
@@ -1919,7 +1919,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2214,7 +2214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5262,7 +5262,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -5651,7 +5651,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5730,7 +5730,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6677,7 +6677,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8276,7 +8276,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8836,7 +8836,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -9022,7 +9022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9588,7 +9588,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9633,7 +9633,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10593,7 +10593,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11404,7 +11404,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/hunk-codex/Cargo.toml
+++ b/crates/hunk-codex/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "2.0"
 tracing = "0.1"
 url = "2.5"
 tungstenite = "0.28"
-codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.114.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.115.0" }
 
 [dev-dependencies]
 tempfile = "3.23"

--- a/crates/hunk-codex/tests/thread_service.rs
+++ b/crates/hunk-codex/tests/thread_service.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
+use codex_app_server_protocol::ApprovalsReviewer;
 use codex_app_server_protocol::AskForApproval;
 use codex_app_server_protocol::CommandExecParams;
 use codex_app_server_protocol::CommandExecResponse;
@@ -1714,6 +1715,7 @@ fn run_loaded_read_fork(socket: &mut WebSocket<TcpStream>) {
             service_tier: None,
             cwd: WORKSPACE_CWD.into(),
             approval_policy: AskForApproval::OnRequest,
+            approvals_reviewer: ApprovalsReviewer::User,
             sandbox: SandboxPolicy::DangerFullAccess,
             reasoning_effort: None,
         },
@@ -2321,6 +2323,7 @@ fn thread_start_response(thread: Thread) -> ThreadStartResponse {
         model_provider: "openai".to_string(),
         service_tier: None,
         approval_policy: AskForApproval::OnRequest,
+        approvals_reviewer: ApprovalsReviewer::User,
         sandbox: SandboxPolicy::DangerFullAccess,
         reasoning_effort: None,
     }
@@ -2334,6 +2337,7 @@ fn thread_resume_response(thread: Thread) -> ThreadResumeResponse {
         model_provider: "openai".to_string(),
         service_tier: None,
         approval_policy: AskForApproval::OnRequest,
+        approvals_reviewer: ApprovalsReviewer::User,
         sandbox: SandboxPolicy::DangerFullAccess,
         reasoning_effort: None,
     }

--- a/crates/hunk-codex/tests/thread_service_snapshot_reconciliation.rs
+++ b/crates/hunk-codex/tests/thread_service_snapshot_reconciliation.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
+use codex_app_server_protocol::ApprovalsReviewer;
 use codex_app_server_protocol::AskForApproval;
 use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCNotification;
@@ -287,6 +288,7 @@ fn thread_resume_response(thread: Thread) -> ThreadResumeResponse {
         model_provider: "openai".to_string(),
         service_tier: None,
         approval_policy: AskForApproval::OnRequest,
+        approvals_reviewer: ApprovalsReviewer::User,
         sandbox: SandboxPolicy::DangerFullAccess,
         reasoning_effort: None,
     }

--- a/crates/hunk-desktop/Cargo.toml
+++ b/crates/hunk-desktop/Cargo.toml
@@ -59,8 +59,8 @@ time = { version = "0.3", features = ["formatting", "local-offset"] }
 hunk-domain = { path = "../hunk-domain" }
 hunk-git = { path = "../hunk-git" }
 hunk-codex = { path = "../hunk-codex" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.114.0" }
-codex-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.114.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.115.0" }
+codex-protocol = { git = "https://github.com/openai/codex.git", tag = "rust-v0.115.0" }
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 git2 = { version = "0.20", features = ["https", "ssh", "vendored-libgit2", "vendored-openssl"] }


### PR DESCRIPTION
Update `codex-app-server-protocol` and `codex-protocol` to `rust-v0.115.0`, and adjust hunk-codex tests to set `approvals_reviewer` explicitly (`User`) for protocol compatibility.