### PR TITLE
Reuse current branch for Open PR unless on default branch

### DIFF
--- a/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
@@ -647,7 +647,14 @@ impl DiffViewer {
         let branch_name = context.branch_name.clone();
         let start_mode = context.start_mode;
         let epoch = self.begin_git_action("Open PR", cx);
-        let create_review_branch = start_mode == AiNewThreadStartMode::Local;
+        let open_pr_branch_strategy = ai_open_pr_branch_strategy(repo_root.as_path(), &branch_name);
+        let create_review_branch =
+            open_pr_branch_strategy == AiOpenPrBranchStrategy::CreateReviewBranch;
+        let branch_detail_label = if create_review_branch {
+            "Review branch"
+        } else {
+            "Branch"
+        };
         let initial_step = if create_review_branch {
             AiGitProgressStep::GeneratingBranchName
         } else {
@@ -671,7 +678,9 @@ impl DiffViewer {
             cx,
             move |progress_tx| {
                 (|| -> anyhow::Result<(Option<String>, String, String)> {
-                    let review_branch_name = if start_mode == AiNewThreadStartMode::Local {
+                    let review_branch_name = if open_pr_branch_strategy
+                        == AiOpenPrBranchStrategy::CreateReviewBranch
+                    {
                         let requested_branch_name = try_ai_branch_name_for_prompt(
                             codex_executable.as_path(),
                             repo_root.as_path(),
@@ -700,7 +709,7 @@ impl DiffViewer {
                         &progress_tx,
                         AiGitProgressStep::GeneratingCommitMessage,
                         Some(ai_branch_progress_detail(
-                            "Review branch",
+                            branch_detail_label,
                             review_branch_name.as_str(),
                         )),
                     );
@@ -734,7 +743,7 @@ impl DiffViewer {
                         &progress_tx,
                         AiGitProgressStep::PushingBranch,
                         Some(ai_branch_progress_detail(
-                            "Review branch",
+                            branch_detail_label,
                             review_branch_name.as_str(),
                         )),
                     );
@@ -747,7 +756,7 @@ impl DiffViewer {
                         &progress_tx,
                         AiGitProgressStep::PreparingReviewUrl,
                         Some(ai_branch_progress_detail(
-                            "Review branch",
+                            branch_detail_label,
                             review_branch_name.as_str(),
                         )),
                     );

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
@@ -23,6 +23,33 @@ fn ai_commit_progress_detail(subject: &str) -> String {
     format!("Commit: {subject}")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AiOpenPrBranchStrategy {
+    CreateReviewBranch,
+    ReuseCurrentBranch,
+}
+
+fn ai_open_pr_branch_strategy(
+    repo_root: &std::path::Path,
+    branch_name: &str,
+) -> AiOpenPrBranchStrategy {
+    let default_branch_name = resolve_default_base_branch_name(repo_root).ok().flatten();
+    ai_open_pr_branch_strategy_for_branch(branch_name, default_branch_name.as_deref())
+}
+
+fn ai_open_pr_branch_strategy_for_branch(
+    branch_name: &str,
+    default_branch_name: Option<&str>,
+) -> AiOpenPrBranchStrategy {
+    let branch_name = branch_name.trim();
+    let default_branch_name = default_branch_name.map(str::trim);
+    if default_branch_name == Some(branch_name) {
+        AiOpenPrBranchStrategy::CreateReviewBranch
+    } else {
+        AiOpenPrBranchStrategy::ReuseCurrentBranch
+    }
+}
+
 fn ai_publish_blocker_reason(
     context: Result<AiThreadGitActionContext, String>,
 ) -> Option<String> {
@@ -184,6 +211,30 @@ mod ai_git_ops_tests {
         assert_eq!(
             ai_publish_blocker_reason(Err("Select a thread before publishing.".to_string())),
             Some("Select a thread before publishing.".to_string())
+        );
+    }
+
+    #[test]
+    fn open_pr_branch_strategy_creates_review_branch_for_default_branch() {
+        assert_eq!(
+            ai_open_pr_branch_strategy_for_branch("main", Some("main")),
+            AiOpenPrBranchStrategy::CreateReviewBranch
+        );
+    }
+
+    #[test]
+    fn open_pr_branch_strategy_reuses_non_default_branch() {
+        assert_eq!(
+            ai_open_pr_branch_strategy_for_branch("feature/ai-thread", Some("main")),
+            AiOpenPrBranchStrategy::ReuseCurrentBranch
+        );
+    }
+
+    #[test]
+    fn open_pr_branch_strategy_reuses_when_default_branch_is_unknown() {
+        assert_eq!(
+            ai_open_pr_branch_strategy_for_branch("feature/ai-thread", None),
+            AiOpenPrBranchStrategy::ReuseCurrentBranch
         );
     }
 }

--- a/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
+++ b/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
@@ -520,7 +520,7 @@ impl DiffViewer {
                         let publish_tooltip = state.ai_publish_blocker.clone().unwrap_or_else(|| {
                             match state.selected_thread_start_mode {
                                 Some(AiNewThreadStartMode::Local) => {
-                                    "Commit and push this branch directly, or create a review branch and open PR/MR.".to_string()
+                                    "Commit and push this branch directly, or open PR/MR for it. If the current branch is the default branch, Hunk creates a review branch first.".to_string()
                                 }
                                 Some(AiNewThreadStartMode::Worktree) => {
                                     "Commit and push this worktree branch directly, or open PR/MR for the current branch.".to_string()

--- a/crates/hunk-desktop/tests/ai_git_progress.rs
+++ b/crates/hunk-desktop/tests/ai_git_progress.rs
@@ -22,7 +22,7 @@ fn commit_and_push_progress_steps_match_publish_flow() {
 }
 
 #[test]
-fn open_pr_progress_steps_include_review_branch_generation_for_local_threads() {
+fn open_pr_progress_steps_include_review_branch_generation_when_needed() {
     let steps = ai_open_pr_progress_steps(true);
 
     assert_eq!(
@@ -40,7 +40,7 @@ fn open_pr_progress_steps_include_review_branch_generation_for_local_threads() {
 }
 
 #[test]
-fn open_pr_progress_steps_skip_branch_creation_for_worktree_threads() {
+fn open_pr_progress_steps_skip_branch_creation_when_reusing_current_branch() {
     let steps = ai_open_pr_progress_steps(false);
 
     assert_eq!(


### PR DESCRIPTION
Detect the repository default branch and only create a review branch when Open PR starts from that branch; otherwise reuse the current branch for commit/push and PR creation. Update Open PR progress labeling and tooltip copy to reflect this behavior, and add tests for branch strategy and progress-step variants.