### PR TITLE
Add Linux DEB/RPM packaging flows and CI artifacts

### DIFF
--- a/.github/workflows/adhoc-release-assets.yml
+++ b/.github/workflows/adhoc-release-assets.yml
@@ -122,7 +122,7 @@ jobs:
           if-no-files-found: error
 
   linux:
-    name: Linux x86_64 AppImage
+    name: Linux x86_64 AppImage, DEB, RPM
     runs-on: ubuntu-24.04
     timeout-minutes: 60
 
@@ -153,10 +153,6 @@ jobs:
           echo "HUNK_RELEASE_VERSION=$version" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Install cargo-packager
-        run: cargo install cargo-packager --locked --version 0.11.8
-        shell: bash
-
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update
@@ -175,7 +171,8 @@ jobs:
             libxkbcommon-x11-dev \
             libzstd-dev \
             patchelf \
-            pkg-config
+            pkg-config \
+            rpm
         shell: bash
 
       - name: Package Linux release artifact
@@ -194,6 +191,20 @@ jobs:
         with:
           name: hunk-linux-x86_64-tarball
           path: ${{ env.CARGO_TARGET_DIR }}/dist/Hunk-${{ env.HUNK_RELEASE_VERSION }}-linux-x86_64.tar.gz
+          if-no-files-found: error
+
+      - name: Upload Linux Debian release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: hunk-linux-x86_64-deb
+          path: ${{ env.CARGO_TARGET_DIR }}/dist/hunk-desktop_${{ env.HUNK_RELEASE_VERSION }}-1_amd64.deb
+          if-no-files-found: error
+
+      - name: Upload Linux RPM release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: hunk-linux-x86_64-rpm
+          path: ${{ env.CARGO_TARGET_DIR }}/dist/*.rpm
           if-no-files-found: error
 
   windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           if-no-files-found: error
 
   linux:
-    name: Linux x86_64 AppImage
+    name: Linux x86_64 AppImage, DEB, RPM
     runs-on: ubuntu-24.04
     timeout-minutes: 60
 
@@ -163,10 +163,6 @@ jobs:
           echo "HUNK_RELEASE_VERSION=$version" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Install cargo-packager
-        run: cargo install cargo-packager --locked --version 0.11.8
-        shell: bash
-
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update
@@ -185,7 +181,8 @@ jobs:
             libxkbcommon-x11-dev \
             libzstd-dev \
             patchelf \
-            pkg-config
+            pkg-config \
+            rpm
         shell: bash
 
       - name: Package Linux release artifact
@@ -204,6 +201,20 @@ jobs:
         with:
           name: hunk-linux-x86_64-tarball
           path: ${{ env.CARGO_TARGET_DIR }}/dist/Hunk-${{ env.HUNK_RELEASE_VERSION }}-linux-x86_64.tar.gz
+          if-no-files-found: error
+
+      - name: Upload Linux Debian release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: hunk-linux-x86_64-deb
+          path: ${{ env.CARGO_TARGET_DIR }}/dist/hunk-desktop_${{ env.HUNK_RELEASE_VERSION }}-1_amd64.deb
+          if-no-files-found: error
+
+      - name: Upload Linux RPM release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: hunk-linux-x86_64-rpm
+          path: ${{ env.CARGO_TARGET_DIR }}/dist/*.rpm
           if-no-files-found: error
 
   windows:

--- a/README.md
+++ b/README.md
@@ -136,10 +136,20 @@ pwsh ./scripts/package_windows_release.ps1
 These produce:
 
 - macOS ARM64: `Hunk-<version>-macos-arm64.dmg`, signed/notarized when Apple secrets are configured
-- Linux x86_64: `Hunk-<version>-linux-x86_64.AppImage` plus fallback `Hunk-<version>-linux-x86_64.tar.gz`
+- Linux x86_64: `Hunk-<version>-linux-x86_64.AppImage`, fallback `Hunk-<version>-linux-x86_64.tar.gz`, `hunk-desktop_<version>-1_amd64.deb`, and `hunk-desktop-<rpm-version>-1.x86_64.rpm`
 - Windows x86_64: `Hunk-<version>-windows-x86_64.msi`
 
-Linux release packaging requires `patchelf` for the tarball fallback bundle.
+Linux release packaging is custom and does not use `cargo packager`. Install Ubuntu build deps with `just install-linux-packaging-deps-ubuntu`, then use:
+
+```bash
+just package-linux-release
+just package-linux-deb-release
+just package-linux-rpm-release
+just smoke-test-linux-deb
+just smoke-test-linux-rpm
+```
+
+The Debian smoke test installs the package in an Ubuntu container. The RPM smoke test installs it in a Fedora container.
 
 ## Prepare Bundled Codex Runtime
 
@@ -196,7 +206,7 @@ just bundle
 ## GitHub Actions Release Flow
 
 - `.github/workflows/pr-build.yml` stays as the main PR CI workflow.
-- `.github/workflows/release.yml` builds DMG/MSI/AppImage artifacts and publishes them to a GitHub Release when you push a `v*` tag.
+- `.github/workflows/release.yml` builds DMG/MSI/AppImage/DEB/RPM artifacts and publishes them to a GitHub Release when you push a `v*` tag.
 
 The release workflows no longer bundle the old Helix runtime. The editor now uses the curated Tree-sitter language set compiled into `hunk-language`.
 

--- a/justfile
+++ b/justfile
@@ -44,6 +44,27 @@ package-macos-release:
 package-linux-release:
     ./scripts/package_linux_release.sh
 
+package-linux-appimage-release:
+    ./scripts/package_linux_release.sh --formats appimage,tarball
+
+package-linux-deb-release:
+    ./scripts/package_linux_release.sh --formats deb
+
+package-linux-rpm-release:
+    ./scripts/package_linux_release.sh --formats rpm
+
+install-linux-packaging-deps-ubuntu:
+    ./scripts/install_linux_packaging_deps_ubuntu.sh
+
+install-linux-deb-local:
+    sudo apt-get install -y "$(./scripts/package_linux_release.sh --formats deb | tail -n 1)"
+
+smoke-test-linux-deb:
+    ./scripts/smoke_test_linux_system_package.sh deb
+
+smoke-test-linux-rpm:
+    ./scripts/smoke_test_linux_system_package.sh rpm
+
 package-windows-release:
     pwsh ./scripts/package_windows_release.ps1
 

--- a/scripts/install_linux_packaging_deps_ubuntu.sh
+++ b/scripts/install_linux_packaging_deps_ubuntu.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "error: Ubuntu packaging dependency install only runs on Linux hosts" >&2
+  exit 1
+fi
+
+if [[ ! -r /etc/os-release ]]; then
+  echo "error: /etc/os-release is unavailable; cannot determine distro" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source /etc/os-release
+if [[ "${ID:-}" != "ubuntu" && "${ID_LIKE:-}" != *debian* ]]; then
+  echo "error: expected an Ubuntu/Debian-style host, got '${PRETTY_NAME:-unknown}'" >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  clang \
+  cmake \
+  libasound2-dev \
+  libfontconfig-dev \
+  libgit2-dev \
+  libglib2.0-dev \
+  libssl-dev \
+  libvulkan1 \
+  libwayland-dev \
+  libx11-xcb-dev \
+  libxkbcommon-x11-dev \
+  libzstd-dev \
+  patchelf \
+  pkg-config \
+  rpm

--- a/scripts/linux_release_common.sh
+++ b/scripts/linux_release_common.sh
@@ -1,0 +1,575 @@
+#!/usr/bin/env bash
+
+if [[ -n "${HUNK_LINUX_RELEASE_COMMON_SOURCED:-}" ]]; then
+  return 0
+fi
+HUNK_LINUX_RELEASE_COMMON_SOURCED=1
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+TARGET_TRIPLE="${HUNK_LINUX_TARGET:-x86_64-unknown-linux-gnu}"
+TARGET_DIR="${CARGO_TARGET_DIR:-$("$ROOT_DIR/scripts/resolve_cargo_target_dir.sh" "$ROOT_DIR")}"
+VERSION_LABEL="${HUNK_RELEASE_VERSION:-$("$ROOT_DIR/scripts/resolve_hunk_version.sh")}"
+PRODUCT_NAME="${HUNK_LINUX_PRODUCT_NAME:-Hunk}"
+PACKAGE_NAME="${HUNK_LINUX_PACKAGE_NAME:-hunk-desktop}"
+PACKAGE_VENDOR="${HUNK_LINUX_PACKAGE_VENDOR:-Nitesh Balusu}"
+PACKAGE_MAINTAINER="${HUNK_LINUX_PACKAGE_MAINTAINER:-Nitesh Balusu <hunk@example.com>}"
+PACKAGE_LICENSE="${HUNK_LINUX_PACKAGE_LICENSE:-LicenseRef-Unknown}"
+PACKAGE_HOMEPAGE="${HUNK_LINUX_PACKAGE_HOMEPAGE:-https://github.com/BlixtWallet/hunk}"
+PACKAGE_SUMMARY="${HUNK_LINUX_PACKAGE_SUMMARY:-Very fast git diff viewer and codex orchestrator.}"
+PACKAGE_DESCRIPTION="${HUNK_LINUX_PACKAGE_DESCRIPTION:-A super fast, simple Git diff viewer and Codex orchestrator built with GPUI.}"
+PACKAGE_SECTION="${HUNK_LINUX_PACKAGE_SECTION:-utils}"
+PACKAGE_PRIORITY="${HUNK_LINUX_PACKAGE_PRIORITY:-optional}"
+PACKAGE_RELEASE="${HUNK_LINUX_PACKAGE_RELEASE:-1}"
+WORK_DIR="$TARGET_DIR/linux-packaging"
+DIST_DIR="$TARGET_DIR/dist"
+ARCH_LABEL=""
+PACKAGE_DIR=""
+ARCHIVE_PATH=""
+APPIMAGE_PATH=""
+APPDIR_PATH=""
+APP_DESKTOP_ENTRY_PATH=""
+APP_ICON_PATH=""
+APPDIR_REAL_BINARY_PATH=""
+APPDIR_LAUNCHER_PATH=""
+SYSTEM_INSTALL_ROOT=""
+SYSTEM_BIN_DIR=""
+SYSTEM_LIB_DIR=""
+SYSTEM_PRIVATE_LIB_DIR=""
+SYSTEM_REAL_BINARY_PATH=""
+SYSTEM_LAUNCHER_PATH=""
+SYSTEM_RUNTIME_PATH=""
+SYSTEM_DESKTOP_ENTRY_PATH=""
+SYSTEM_ICON_DIR=""
+SYSTEM_ICON_PATH=""
+SYSTEM_ICON_ALIAS_PATH=""
+SYSTEM_WRAPPER_PATH=""
+SYSTEM_WRAPPER_ALIAS_PATH=""
+DEB_BUILD_ROOT=""
+DEB_ARCH=""
+DEB_VERSION=""
+DEB_PATH=""
+RPM_TOPDIR=""
+RPM_ARCH=""
+RPM_VERSION=""
+RPM_PATH=""
+BINARY_SOURCE_PATH=""
+REAL_BINARY_NAME="hunk_desktop_bin"
+LAUNCHER_SOURCE_PATH="$ROOT_DIR/scripts/linux_gui_binary_launcher.sh"
+PACKAGED_BINARY_PATH=""
+PACKAGED_LAUNCHER_PATH=""
+PACKAGE_LIB_DIR=""
+CODEX_SOURCE_PATH=""
+PACKAGED_CODEX_PATH=""
+APPIMAGE_TOOL_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/hunk-appimage-tools"
+APPIMAGE_APPRUN_PATH="$APPIMAGE_TOOL_CACHE_DIR/AppRun-x86_64"
+APPIMAGE_PLUGIN_PATH="$APPIMAGE_TOOL_CACHE_DIR/linuxdeploy-plugin-appimage.AppImage"
+APPIMAGE_TOOL_EXTRACT_DIR=""
+APPIMAGE_TOOL_PATH=""
+
+linux_target_arch() {
+  printf '%s\n' "${TARGET_TRIPLE%%-*}"
+}
+
+linux_dist_arch_label() {
+  case "$(linux_target_arch)" in
+    x86_64)
+      printf '%s\n' "x86_64"
+      ;;
+    aarch64)
+      printf '%s\n' "arm64"
+      ;;
+    *)
+      printf '%s\n' "$(linux_target_arch)"
+      ;;
+  esac
+}
+
+linux_deb_arch() {
+  case "$(linux_target_arch)" in
+    x86_64)
+      printf '%s\n' "amd64"
+      ;;
+    aarch64)
+      printf '%s\n' "arm64"
+      ;;
+    armv7*)
+      printf '%s\n' "armhf"
+      ;;
+    *)
+      echo "error: unsupported Debian architecture for target '$TARGET_TRIPLE'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+linux_rpm_arch() {
+  case "$(linux_target_arch)" in
+    x86_64)
+      printf '%s\n' "x86_64"
+      ;;
+    aarch64)
+      printf '%s\n' "aarch64"
+      ;;
+    *)
+      printf '%s\n' "$(linux_target_arch)"
+      ;;
+  esac
+}
+
+linux_deb_version() {
+  printf '%s-%s\n' "$VERSION_LABEL" "$PACKAGE_RELEASE"
+}
+
+linux_rpm_version() {
+  local version="$VERSION_LABEL"
+  if [[ "$version" == *-* ]]; then
+    local base="${version%%-*}"
+    local suffix="${version#*-}"
+    suffix="${suffix//-/_}"
+    printf '%s~%s\n' "$base" "$suffix"
+  else
+    printf '%s\n' "$version"
+  fi
+}
+
+linux_rpm_changelog_date() {
+  LC_ALL=C date -u +"%a %b %d %Y"
+}
+
+init_linux_release_paths() {
+  ARCH_LABEL="$(linux_dist_arch_label)"
+  PACKAGE_DIR="$WORK_DIR/tarball/${PRODUCT_NAME}-${VERSION_LABEL}-linux-$ARCH_LABEL"
+  ARCHIVE_PATH="$DIST_DIR/${PRODUCT_NAME}-${VERSION_LABEL}-linux-$ARCH_LABEL.tar.gz"
+  APPIMAGE_PATH="$DIST_DIR/${PRODUCT_NAME}-${VERSION_LABEL}-linux-$ARCH_LABEL.AppImage"
+  APPDIR_PATH="$WORK_DIR/appimage/${PRODUCT_NAME}.AppDir"
+  APP_DESKTOP_ENTRY_PATH="$APPDIR_PATH/usr/share/applications/hunk_desktop.desktop"
+  APP_ICON_PATH="$APPDIR_PATH/usr/share/icons/hicolor/1024x1024/apps/hunk_desktop.png"
+  APPDIR_REAL_BINARY_PATH="$APPDIR_PATH/usr/bin/$REAL_BINARY_NAME"
+  APPDIR_LAUNCHER_PATH="$APPDIR_PATH/usr/bin/hunk_desktop"
+  SYSTEM_INSTALL_ROOT="$WORK_DIR/system-root"
+  SYSTEM_BIN_DIR="$SYSTEM_INSTALL_ROOT/usr/bin"
+  SYSTEM_LIB_DIR="$SYSTEM_INSTALL_ROOT/usr/lib/$PACKAGE_NAME"
+  SYSTEM_PRIVATE_LIB_DIR="$SYSTEM_LIB_DIR/lib"
+  SYSTEM_REAL_BINARY_PATH="$SYSTEM_LIB_DIR/$REAL_BINARY_NAME"
+  SYSTEM_LAUNCHER_PATH="$SYSTEM_LIB_DIR/$PACKAGE_NAME"
+  SYSTEM_RUNTIME_PATH="$SYSTEM_LIB_DIR/codex-runtime/linux/codex"
+  SYSTEM_DESKTOP_ENTRY_PATH="$SYSTEM_INSTALL_ROOT/usr/share/applications/$PACKAGE_NAME.desktop"
+  SYSTEM_ICON_DIR="$SYSTEM_INSTALL_ROOT/usr/share/icons/hicolor/1024x1024/apps"
+  SYSTEM_ICON_PATH="$SYSTEM_ICON_DIR/$PACKAGE_NAME.png"
+  SYSTEM_ICON_ALIAS_PATH="$SYSTEM_ICON_DIR/${PACKAGE_NAME//-/_}.png"
+  SYSTEM_WRAPPER_PATH="$SYSTEM_BIN_DIR/$PACKAGE_NAME"
+  SYSTEM_WRAPPER_ALIAS_PATH="$SYSTEM_BIN_DIR/${PACKAGE_NAME//-/_}"
+  DEB_BUILD_ROOT="$WORK_DIR/deb-root"
+  DEB_ARCH="$(linux_deb_arch)"
+  DEB_VERSION="$(linux_deb_version)"
+  DEB_PATH="$DIST_DIR/${PACKAGE_NAME}_${DEB_VERSION}_${DEB_ARCH}.deb"
+  RPM_TOPDIR="$WORK_DIR/rpmbuild"
+  RPM_ARCH="$(linux_rpm_arch)"
+  RPM_VERSION="$(linux_rpm_version)"
+  RPM_PATH="$DIST_DIR/${PACKAGE_NAME}-${RPM_VERSION}-${PACKAGE_RELEASE}.${RPM_ARCH}.rpm"
+  BINARY_SOURCE_PATH="$TARGET_DIR/$TARGET_TRIPLE/release/hunk_desktop"
+  PACKAGED_BINARY_PATH="$PACKAGE_DIR/$REAL_BINARY_NAME"
+  PACKAGED_LAUNCHER_PATH="$PACKAGE_DIR/$PACKAGE_NAME"
+  PACKAGE_LIB_DIR="$PACKAGE_DIR/lib"
+  CODEX_SOURCE_PATH="$TARGET_DIR/$TARGET_TRIPLE/release/codex-runtime/linux/codex"
+  PACKAGED_CODEX_PATH="$PACKAGE_DIR/codex-runtime/linux/codex"
+  APPIMAGE_TOOL_EXTRACT_DIR="$WORK_DIR/appimage/tooling"
+  APPIMAGE_TOOL_PATH="$APPIMAGE_TOOL_EXTRACT_DIR/squashfs-root/usr/bin/appimagetool"
+}
+
+require_linux_tool() {
+  local tool_name="$1"
+  if ! command -v "$tool_name" >/dev/null 2>&1; then
+    echo "error: required Linux packaging tool '$tool_name' is not installed" >&2
+    exit 1
+  fi
+}
+
+download_cached_appimage_tool() {
+  local url="$1"
+  local destination="$2"
+  local tmp_path
+
+  mkdir -p "$(dirname "$destination")"
+  tmp_path="$(mktemp "${destination}.XXXXXX")"
+  curl --fail --location --retry 3 --retry-delay 1 --output "$tmp_path" "$url"
+  chmod 755 "$tmp_path"
+  mv "$tmp_path" "$destination"
+}
+
+ensure_appimage_tooling() {
+  if [[ ! -f "$APPIMAGE_APPRUN_PATH" ]]; then
+    echo "Downloading AppRun helper..." >&2
+    download_cached_appimage_tool \
+      "https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-x86_64" \
+      "$APPIMAGE_APPRUN_PATH"
+  fi
+
+  if [[ ! -f "$APPIMAGE_PLUGIN_PATH" ]]; then
+    echo "Downloading appimagetool bundle..." >&2
+    download_cached_appimage_tool \
+      "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage" \
+      "$APPIMAGE_PLUGIN_PATH"
+  fi
+
+  rm -rf "$APPIMAGE_TOOL_EXTRACT_DIR"
+  mkdir -p "$APPIMAGE_TOOL_EXTRACT_DIR"
+  (
+    cd "$APPIMAGE_TOOL_EXTRACT_DIR"
+    "$APPIMAGE_PLUGIN_PATH" --appimage-extract >/dev/null
+  )
+
+  if [[ ! -x "$APPIMAGE_TOOL_PATH" ]]; then
+    echo "error: expected appimagetool at $APPIMAGE_TOOL_PATH" >&2
+    exit 1
+  fi
+}
+
+should_bundle_linux_library() {
+  local library_name="$1"
+
+  case "$library_name" in
+    linux-vdso.so.*|linux-gate.so.*|ld-linux*.so.*|ld-musl-*.so.*)
+      return 1
+      ;;
+    libc.so.*|libm.so.*|libpthread.so.*|librt.so.*|libdl.so.*|libutil.so.*|libresolv.so.*|libnsl.so.*|libanl.so.*|libBrokenLocale.so.*)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+list_linux_runtime_dependencies() {
+  local target_path="$1"
+  local ldd_output
+
+  ldd_output="$(ldd "$target_path")"
+  if grep -Fq "not found" <<<"$ldd_output"; then
+    echo "error: unresolved Linux runtime dependencies for $target_path" >&2
+    echo "$ldd_output" >&2
+    exit 1
+  fi
+
+  while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"
+
+    if [[ "$line" == *"=>"* ]]; then
+      line="${line#*=> }"
+    elif [[ "$line" != /* ]]; then
+      continue
+    fi
+
+    line="${line%% *}"
+    if [[ "$line" == /* ]]; then
+      printf '%s\n' "$line"
+    fi
+  done <<<"$ldd_output"
+}
+
+bundle_linux_runtime_dependencies() {
+  local root_binary="$1"
+  local destination_dir="$2"
+  local -A seen_paths=()
+  local -A seen_names=()
+  local -a queue=("$root_binary")
+
+  while [[ ${#queue[@]} -gt 0 ]]; do
+    local current="${queue[0]}"
+    queue=("${queue[@]:1}")
+
+    while IFS= read -r dependency_path; do
+      [[ -n "$dependency_path" ]] || continue
+
+      local dependency_name
+      dependency_name="$(basename "$dependency_path")"
+      if ! should_bundle_linux_library "$dependency_name"; then
+        continue
+      fi
+
+      if [[ -n "${seen_paths[$dependency_path]:-}" ]]; then
+        continue
+      fi
+
+      if [[ -n "${seen_names[$dependency_name]:-}" && "${seen_names[$dependency_name]}" != "$dependency_path" ]]; then
+        echo "error: conflicting Linux dependency paths for $dependency_name:" >&2
+        echo "  ${seen_names[$dependency_name]}" >&2
+        echo "  $dependency_path" >&2
+        exit 1
+      fi
+
+      seen_paths["$dependency_path"]=1
+      seen_names["$dependency_name"]="$dependency_path"
+
+      echo "Bundling Linux dependency $dependency_name from $dependency_path" >&2
+      cp -L "$dependency_path" "$destination_dir/$dependency_name"
+      chmod 755 "$destination_dir/$dependency_name"
+      queue+=("$dependency_path")
+    done < <(list_linux_runtime_dependencies "$current")
+  done
+}
+
+patch_linux_runtime_paths() {
+  local binary_path="$1"
+  local libs_dir="$2"
+  local binary_rpath="$3"
+
+  patchelf --set-rpath "$binary_rpath" "$binary_path"
+
+  if [[ -d "$libs_dir" ]]; then
+    while IFS= read -r -d '' library_path; do
+      patchelf --set-rpath '$ORIGIN' "$library_path"
+    done < <(find "$libs_dir" -maxdepth 1 -type f -name '*.so*' -print0)
+  fi
+}
+
+validate_linux_runtime_bundle() {
+  local binary_path="$1"
+  local libs_dir="$2"
+  local ldd_output
+
+  ldd_output="$(env LD_LIBRARY_PATH="$libs_dir" ldd "$binary_path")"
+  if grep -Fq "not found" <<<"$ldd_output"; then
+    echo "error: bundled Linux runtime dependencies are incomplete for $binary_path" >&2
+    echo "$ldd_output" >&2
+    exit 1
+  fi
+}
+
+prepare_linux_release_build_inputs() {
+  require_linux_tool patchelf
+
+  echo "Downloading bundled Codex runtime for Linux..." >&2
+  "$ROOT_DIR/scripts/download_codex_runtime_unix.sh" linux >/dev/null
+  echo "Validating bundled Codex runtime for Linux..." >&2
+  "$ROOT_DIR/scripts/validate_codex_runtime_bundle.sh" --strict --platform linux >/dev/null
+  echo "Building Linux release binary..." >&2
+  (
+    cd "$ROOT_DIR"
+    export CARGO_TARGET_DIR="$TARGET_DIR"
+    "$ROOT_DIR/scripts/build_linux.sh" --target "$TARGET_TRIPLE"
+  )
+}
+
+prepare_linux_release_bundle() {
+  prepare_linux_release_build_inputs
+
+  rm -rf "$PACKAGE_DIR"
+  mkdir -p "$PACKAGE_DIR/codex-runtime/linux" "$PACKAGE_LIB_DIR" "$DIST_DIR"
+
+  cp "$BINARY_SOURCE_PATH" "$PACKAGED_BINARY_PATH"
+  cp "$LAUNCHER_SOURCE_PATH" "$PACKAGED_LAUNCHER_PATH"
+  cp "$CODEX_SOURCE_PATH" "$PACKAGED_CODEX_PATH"
+  chmod +x "$PACKAGED_BINARY_PATH" "$PACKAGED_LAUNCHER_PATH" "$PACKAGED_CODEX_PATH"
+
+  echo "Bundling Linux shared libraries into release bundle..." >&2
+  bundle_linux_runtime_dependencies "$BINARY_SOURCE_PATH" "$PACKAGE_LIB_DIR"
+  patch_linux_runtime_paths "$PACKAGED_BINARY_PATH" "$PACKAGE_LIB_DIR" '$ORIGIN/lib'
+  validate_linux_runtime_bundle "$PACKAGED_BINARY_PATH" "$PACKAGE_LIB_DIR"
+  "$ROOT_DIR/scripts/validate_release_bundle_layout.sh" linux-package "$PACKAGE_DIR"
+}
+
+create_linux_appdir() {
+  rm -rf "$APPDIR_PATH"
+  mkdir -p "$APPDIR_PATH/usr/bin"
+  mkdir -p "$APPDIR_PATH/usr/lib"
+  mkdir -p "$APPDIR_PATH/usr/share/applications"
+  mkdir -p "$APPDIR_PATH/usr/share/icons/hicolor/1024x1024/apps"
+  mkdir -p "$APPDIR_PATH/usr/lib/hunk_desktop/codex-runtime/linux"
+
+  cp "$APPIMAGE_APPRUN_PATH" "$APPDIR_PATH/AppRun"
+  cp "$PACKAGED_BINARY_PATH" "$APPDIR_REAL_BINARY_PATH"
+  cp "$PACKAGED_LAUNCHER_PATH" "$APPDIR_LAUNCHER_PATH"
+  cp -R "$PACKAGE_LIB_DIR/." "$APPDIR_PATH/usr/lib/"
+  cp "$PACKAGED_CODEX_PATH" "$APPDIR_PATH/usr/lib/hunk_desktop/codex-runtime/linux/codex"
+  chmod +x "$APPDIR_PATH/AppRun" "$APPDIR_REAL_BINARY_PATH" "$APPDIR_LAUNCHER_PATH" \
+    "$APPDIR_PATH/usr/lib/hunk_desktop/codex-runtime/linux/codex"
+
+  patch_linux_runtime_paths "$APPDIR_REAL_BINARY_PATH" "$APPDIR_PATH/usr/lib" '$ORIGIN/../lib'
+  validate_linux_runtime_bundle "$APPDIR_REAL_BINARY_PATH" "$APPDIR_PATH/usr/lib"
+  "$ROOT_DIR/scripts/validate_release_bundle_layout.sh" linux-appdir "$APPDIR_PATH"
+
+  cat >"$APP_DESKTOP_ENTRY_PATH" <<'EOF'
+[Desktop Entry]
+Categories=Development;
+Comment=Very fast git diff viewer and codex orchestrator.
+Exec=hunk_desktop
+Icon=hunk_desktop
+Name=Hunk
+StartupNotify=true
+StartupWMClass=hunk_desktop
+Terminal=false
+Type=Application
+EOF
+
+  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$APP_ICON_PATH"
+  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$APPDIR_PATH/.DirIcon"
+  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$APPDIR_PATH/hunk_desktop.png"
+  ln -sf "usr/share/applications/hunk_desktop.desktop" "$APPDIR_PATH/hunk_desktop.desktop"
+}
+
+build_linux_appimage() {
+  ensure_appimage_tooling
+  create_linux_appdir
+
+  ARCH=x86_64 "$APPIMAGE_TOOL_PATH" "$APPDIR_PATH" "$APPIMAGE_PATH"
+  chmod +x "$APPIMAGE_PATH"
+}
+
+write_linux_system_wrapper() {
+  local wrapper_path="$1"
+  local launcher_path="$2"
+
+  cat >"$wrapper_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$launcher_path" "\$@"
+EOF
+  chmod 755 "$wrapper_path"
+}
+
+write_linux_system_desktop_entry() {
+  cat >"$SYSTEM_DESKTOP_ENTRY_PATH" <<EOF
+[Desktop Entry]
+Categories=Development;
+Comment=$PACKAGE_SUMMARY
+Exec=$PACKAGE_NAME
+Icon=$PACKAGE_NAME
+Name=$PRODUCT_NAME
+StartupNotify=true
+StartupWMClass=hunk_desktop
+Terminal=false
+Type=Application
+EOF
+}
+
+prepare_linux_system_install_root() {
+  rm -rf "$SYSTEM_INSTALL_ROOT"
+  mkdir -p "$SYSTEM_BIN_DIR" "$SYSTEM_PRIVATE_LIB_DIR" "$(dirname "$SYSTEM_RUNTIME_PATH")" "$SYSTEM_ICON_DIR" "$(dirname "$SYSTEM_DESKTOP_ENTRY_PATH")"
+
+  cp "$PACKAGED_BINARY_PATH" "$SYSTEM_REAL_BINARY_PATH"
+  cp "$PACKAGED_LAUNCHER_PATH" "$SYSTEM_LAUNCHER_PATH"
+  cp -R "$PACKAGE_LIB_DIR/." "$SYSTEM_PRIVATE_LIB_DIR/"
+  cp "$PACKAGED_CODEX_PATH" "$SYSTEM_RUNTIME_PATH"
+  chmod +x "$SYSTEM_REAL_BINARY_PATH" "$SYSTEM_LAUNCHER_PATH" "$SYSTEM_RUNTIME_PATH"
+
+  patch_linux_runtime_paths "$SYSTEM_REAL_BINARY_PATH" "$SYSTEM_PRIVATE_LIB_DIR" '$ORIGIN/lib'
+  validate_linux_runtime_bundle "$SYSTEM_REAL_BINARY_PATH" "$SYSTEM_PRIVATE_LIB_DIR"
+
+  write_linux_system_wrapper "$SYSTEM_WRAPPER_PATH" "/usr/lib/$PACKAGE_NAME/$PACKAGE_NAME"
+  write_linux_system_wrapper "$SYSTEM_WRAPPER_ALIAS_PATH" "/usr/lib/$PACKAGE_NAME/$PACKAGE_NAME"
+  write_linux_system_desktop_entry
+
+  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$SYSTEM_ICON_PATH"
+  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$SYSTEM_ICON_ALIAS_PATH"
+
+  "$ROOT_DIR/scripts/validate_release_bundle_layout.sh" linux-install-root "$SYSTEM_INSTALL_ROOT"
+}
+
+linux_deb_installed_size_kib() {
+  du -sk "$DEB_BUILD_ROOT" | awk '{print $1}'
+}
+
+write_linux_deb_control_file() {
+  local control_path="$1"
+
+  {
+    printf 'Package: %s\n' "$PACKAGE_NAME"
+    printf 'Version: %s\n' "$DEB_VERSION"
+    printf 'Section: %s\n' "$PACKAGE_SECTION"
+    printf 'Priority: %s\n' "$PACKAGE_PRIORITY"
+    printf 'Architecture: %s\n' "$DEB_ARCH"
+    printf 'Maintainer: %s\n' "$PACKAGE_MAINTAINER"
+    printf 'Installed-Size: %s\n' "$(linux_deb_installed_size_kib)"
+    if [[ -n "${HUNK_LINUX_DEB_DEPENDS:-}" ]]; then
+      printf 'Depends: %s\n' "$HUNK_LINUX_DEB_DEPENDS"
+    fi
+    if [[ -n "$PACKAGE_HOMEPAGE" ]]; then
+      printf 'Homepage: %s\n' "$PACKAGE_HOMEPAGE"
+    fi
+    printf 'Description: %s\n' "$PACKAGE_SUMMARY"
+    printf ' %s\n' "$PACKAGE_DESCRIPTION"
+  } >"$control_path"
+}
+
+build_linux_deb_package() {
+  require_linux_tool dpkg-deb
+
+  rm -rf "$DEB_BUILD_ROOT" "$DEB_PATH"
+  mkdir -p "$DEB_BUILD_ROOT"
+  cp -a "$SYSTEM_INSTALL_ROOT/." "$DEB_BUILD_ROOT/"
+  mkdir -p "$DEB_BUILD_ROOT/DEBIAN"
+  write_linux_deb_control_file "$DEB_BUILD_ROOT/DEBIAN/control"
+
+  dpkg-deb --root-owner-group --build "$DEB_BUILD_ROOT" "$DEB_PATH" >/dev/null
+  echo "Created Linux Debian package at $DEB_PATH" >&2
+}
+
+write_linux_rpm_spec() {
+  local spec_path="$1"
+
+  {
+    printf '%%global _build_id_links none\n'
+    printf 'Name:           %s\n' "$PACKAGE_NAME"
+    printf 'Version:        %s\n' "$RPM_VERSION"
+    printf 'Release:        %s\n' "$PACKAGE_RELEASE"
+    printf 'Summary:        %s\n' "$PACKAGE_SUMMARY"
+    printf 'License:        %s\n' "$PACKAGE_LICENSE"
+    printf 'Packager:       %s\n' "$PACKAGE_MAINTAINER"
+    if [[ -n "$PACKAGE_HOMEPAGE" ]]; then
+      printf 'URL:            %s\n' "$PACKAGE_HOMEPAGE"
+    fi
+    printf 'BuildArch:      %s\n' "$RPM_ARCH"
+    printf '\n'
+    printf '%%description\n'
+    printf '%s\n' "$PACKAGE_DESCRIPTION"
+    printf '\n'
+    printf '%%prep\n'
+    printf '\n'
+    printf '%%build\n'
+    printf '\n'
+    printf '%%install\n'
+    printf 'rm -rf %%{buildroot}\n'
+    printf 'mkdir -p %%{buildroot}\n'
+    printf 'cp -a %%{_hunk_install_root}/. %%{buildroot}/\n'
+    printf '\n'
+    printf '%%files\n'
+    printf '/usr/bin/%s\n' "$PACKAGE_NAME"
+    printf '/usr/bin/%s\n' "${PACKAGE_NAME//-/_}"
+    printf '/usr/lib/%s\n' "$PACKAGE_NAME"
+    printf '/usr/share/applications/%s.desktop\n' "$PACKAGE_NAME"
+    printf '/usr/share/icons/hicolor/1024x1024/apps/%s.png\n' "$PACKAGE_NAME"
+    printf '/usr/share/icons/hicolor/1024x1024/apps/%s.png\n' "${PACKAGE_NAME//-/_}"
+    printf '\n'
+    printf '%%changelog\n'
+    printf '* %s %s - %s-%s\n' "$(linux_rpm_changelog_date)" "$PACKAGE_MAINTAINER" "$RPM_VERSION" "$PACKAGE_RELEASE"
+    printf '%s\n' '- Package release build.'
+  } >"$spec_path"
+}
+
+build_linux_rpm_package() {
+  require_linux_tool rpmbuild
+
+  rm -rf "$RPM_TOPDIR" "$RPM_PATH"
+  mkdir -p "$RPM_TOPDIR/BUILD" "$RPM_TOPDIR/BUILDROOT" "$RPM_TOPDIR/RPMS" "$RPM_TOPDIR/SOURCES" "$RPM_TOPDIR/SPECS" "$RPM_TOPDIR/SRPMS"
+
+  local spec_path="$RPM_TOPDIR/SPECS/$PACKAGE_NAME.spec"
+  write_linux_rpm_spec "$spec_path"
+
+  rpmbuild \
+    --define "_topdir $RPM_TOPDIR" \
+    --define "_hunk_install_root $SYSTEM_INSTALL_ROOT" \
+    --nodebuginfo \
+    -bb "$spec_path" >/dev/null
+
+  local built_rpm
+  built_rpm="$(find "$RPM_TOPDIR/RPMS" -type f -name "*.rpm" | sort | head -n 1)"
+  if [[ -z "$built_rpm" ]]; then
+    echo "error: rpmbuild did not produce an RPM under $RPM_TOPDIR/RPMS" >&2
+    exit 1
+  fi
+
+  cp "$built_rpm" "$RPM_PATH"
+  echo "Created Linux RPM package at $RPM_PATH" >&2
+}

--- a/scripts/package_linux_release.sh
+++ b/scripts/package_linux_release.sh
@@ -2,267 +2,117 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TARGET_TRIPLE="${HUNK_LINUX_TARGET:-x86_64-unknown-linux-gnu}"
-TARGET_DIR="$("$ROOT_DIR/scripts/resolve_cargo_target_dir.sh" "$ROOT_DIR")"
-VERSION_LABEL="${HUNK_RELEASE_VERSION:-$("$ROOT_DIR/scripts/resolve_hunk_version.sh")}"
-DIST_DIR="$TARGET_DIR/dist"
-PACKAGE_DIR="$DIST_DIR/Hunk-$VERSION_LABEL-linux-x86_64"
-ARCHIVE_PATH="$DIST_DIR/Hunk-$VERSION_LABEL-linux-x86_64.tar.gz"
-APPIMAGE_PATH="$DIST_DIR/Hunk-$VERSION_LABEL-linux-x86_64.AppImage"
-BINARY_SOURCE_PATH="$TARGET_DIR/$TARGET_TRIPLE/release/hunk_desktop"
-REAL_BINARY_NAME="hunk_desktop_bin"
-LAUNCHER_SOURCE_PATH="$ROOT_DIR/scripts/linux_gui_binary_launcher.sh"
-PACKAGED_BINARY_PATH="$PACKAGE_DIR/$REAL_BINARY_NAME"
-PACKAGED_LAUNCHER_PATH="$PACKAGE_DIR/hunk-desktop"
-PACKAGE_LIB_DIR="$PACKAGE_DIR/lib"
-CODEX_SOURCE_PATH="$TARGET_DIR/$TARGET_TRIPLE/release/codex-runtime/linux/codex"
-PACKAGED_CODEX_PATH="$PACKAGE_DIR/codex-runtime/linux/codex"
-APPDIR_PATH="$TARGET_DIR/appimage/Hunk.AppDir"
-APPIMAGE_TOOL_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/hunk-appimage-tools"
-APPIMAGE_APPRUN_PATH="$APPIMAGE_TOOL_CACHE_DIR/AppRun-x86_64"
-APPIMAGE_PLUGIN_PATH="$APPIMAGE_TOOL_CACHE_DIR/linuxdeploy-plugin-appimage.AppImage"
-APPIMAGE_TOOL_EXTRACT_DIR="$TARGET_DIR/appimage/tooling"
-APPIMAGE_TOOL_PATH="$APPIMAGE_TOOL_EXTRACT_DIR/squashfs-root/usr/bin/appimagetool"
-APP_DESKTOP_ENTRY_PATH="$APPDIR_PATH/usr/share/applications/hunk_desktop.desktop"
-APP_ICON_PATH="$APPDIR_PATH/usr/share/icons/hicolor/1024x1024/apps/hunk_desktop.png"
-APPDIR_REAL_BINARY_PATH="$APPDIR_PATH/usr/bin/$REAL_BINARY_NAME"
-APPDIR_LAUNCHER_PATH="$APPDIR_PATH/usr/bin/hunk_desktop"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/linux_release_common.sh"
+init_linux_release_paths
 
-download_cached_appimage_tool() {
-  local url="$1"
-  local destination="$2"
-  local tmp_path
+usage() {
+  cat <<'EOF'
+Build Linux release artifacts for Hunk.
 
-  mkdir -p "$(dirname "$destination")"
-  tmp_path="$(mktemp "${destination}.XXXXXX")"
-  curl --fail --location --retry 3 --retry-delay 1 --output "$tmp_path" "$url"
-  chmod 755 "$tmp_path"
-  mv "$tmp_path" "$destination"
-}
+Usage:
+  ./scripts/package_linux_release.sh [--formats <csv>]
 
-ensure_appimage_tooling() {
-  if [[ ! -f "$APPIMAGE_APPRUN_PATH" ]]; then
-    echo "Downloading AppRun helper..." >&2
-    download_cached_appimage_tool \
-      "https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-x86_64" \
-      "$APPIMAGE_APPRUN_PATH"
-  fi
+Formats:
+  appimage
+  tarball
+  deb
+  rpm
+  all
 
-  if [[ ! -f "$APPIMAGE_PLUGIN_PATH" ]]; then
-    echo "Downloading appimagetool bundle..." >&2
-    download_cached_appimage_tool \
-      "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage" \
-      "$APPIMAGE_PLUGIN_PATH"
-  fi
-
-  rm -rf "$APPIMAGE_TOOL_EXTRACT_DIR"
-  mkdir -p "$APPIMAGE_TOOL_EXTRACT_DIR"
-  (
-    cd "$APPIMAGE_TOOL_EXTRACT_DIR"
-    "$APPIMAGE_PLUGIN_PATH" --appimage-extract >/dev/null
-  )
-
-  if [[ ! -x "$APPIMAGE_TOOL_PATH" ]]; then
-    echo "error: expected appimagetool at $APPIMAGE_TOOL_PATH" >&2
-    exit 1
-  fi
-}
-
-create_linux_appdir() {
-  rm -rf "$APPDIR_PATH"
-  mkdir -p "$APPDIR_PATH/usr/bin"
-  mkdir -p "$APPDIR_PATH/usr/lib"
-  mkdir -p "$APPDIR_PATH/usr/share/applications"
-  mkdir -p "$APPDIR_PATH/usr/share/icons/hicolor/1024x1024/apps"
-  mkdir -p "$APPDIR_PATH/usr/lib/hunk_desktop/codex-runtime/linux"
-
-  cp "$APPIMAGE_APPRUN_PATH" "$APPDIR_PATH/AppRun"
-  cp "$PACKAGED_BINARY_PATH" "$APPDIR_REAL_BINARY_PATH"
-  cp "$PACKAGED_LAUNCHER_PATH" "$APPDIR_LAUNCHER_PATH"
-  cp -R "$PACKAGE_LIB_DIR/." "$APPDIR_PATH/usr/lib/"
-  cp "$PACKAGED_CODEX_PATH" "$APPDIR_PATH/usr/lib/hunk_desktop/codex-runtime/linux/codex"
-  chmod +x "$APPDIR_PATH/AppRun" "$APPDIR_REAL_BINARY_PATH" "$APPDIR_LAUNCHER_PATH" \
-    "$APPDIR_PATH/usr/lib/hunk_desktop/codex-runtime/linux/codex"
-
-  patch_linux_runtime_paths "$APPDIR_REAL_BINARY_PATH" "$APPDIR_PATH/usr/lib" '$ORIGIN/../lib'
-  validate_linux_runtime_bundle "$APPDIR_REAL_BINARY_PATH" "$APPDIR_PATH/usr/lib"
-  "$ROOT_DIR/scripts/validate_release_bundle_layout.sh" linux-appdir "$APPDIR_PATH"
-
-  cat >"$APP_DESKTOP_ENTRY_PATH" <<'EOF'
-[Desktop Entry]
-Categories=Development;
-Comment=Very fast git diff viewer and codex orchestrator.
-Exec=hunk_desktop
-Icon=hunk_desktop
-Name=Hunk
-StartupNotify=true
-StartupWMClass=hunk_desktop
-Terminal=false
-Type=Application
+Defaults to: appimage,tarball,deb,rpm
 EOF
-
-  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$APP_ICON_PATH"
-  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$APPDIR_PATH/.DirIcon"
-  cp "$ROOT_DIR/assets/icons/hunk_new.png" "$APPDIR_PATH/hunk_desktop.png"
-  ln -sf "usr/share/applications/hunk_desktop.desktop" "$APPDIR_PATH/hunk_desktop.desktop"
 }
 
-build_linux_appimage() {
-  ensure_appimage_tooling
-  create_linux_appdir
+FORMATS="appimage,tarball,deb,rpm"
 
-  ARCH=x86_64 "$APPIMAGE_TOOL_PATH" "$APPDIR_PATH" "$APPIMAGE_PATH"
-}
-
-should_bundle_linux_library() {
-  local library_name="$1"
-
-  case "$library_name" in
-    linux-vdso.so.*|linux-gate.so.*|ld-linux*.so.*|ld-musl-*.so.*)
-      return 1
-      ;;
-    libc.so.*|libm.so.*|libpthread.so.*|librt.so.*|libdl.so.*|libutil.so.*|libresolv.so.*|libnsl.so.*|libanl.so.*|libBrokenLocale.so.*)
-      return 1
-      ;;
-    *)
-      return 0
-      ;;
-  esac
-}
-
-list_linux_runtime_dependencies() {
-  local target_path="$1"
-  local ldd_output
-
-  ldd_output="$(ldd "$target_path")"
-  if grep -Fq "not found" <<<"$ldd_output"; then
-    echo "error: unresolved Linux runtime dependencies for $target_path" >&2
-    echo "$ldd_output" >&2
-    exit 1
-  fi
-
-  while IFS= read -r line; do
-    line="${line#"${line%%[![:space:]]*}"}"
-
-    if [[ "$line" == *"=>"* ]]; then
-      line="${line#*=> }"
-    elif [[ "$line" != /* ]]; then
-      continue
-    fi
-
-    line="${line%% *}"
-    if [[ "$line" == /* ]]; then
-      printf '%s\n' "$line"
-    fi
-  done <<<"$ldd_output"
-}
-
-bundle_linux_runtime_dependencies() {
-  local -A seen_paths=()
-  local -A seen_names=()
-  local -a queue=("$1")
-
-  while [[ ${#queue[@]} -gt 0 ]]; do
-    local current="${queue[0]}"
-    queue=("${queue[@]:1}")
-
-    while IFS= read -r dependency_path; do
-      [[ -n "$dependency_path" ]] || continue
-
-      local dependency_name
-      dependency_name="$(basename "$dependency_path")"
-      if ! should_bundle_linux_library "$dependency_name"; then
-        continue
-      fi
-
-      if [[ -n "${seen_paths[$dependency_path]:-}" ]]; then
-        continue
-      fi
-
-      if [[ -n "${seen_names[$dependency_name]:-}" && "${seen_names[$dependency_name]}" != "$dependency_path" ]]; then
-        echo "error: conflicting Linux dependency paths for $dependency_name:" >&2
-        echo "  ${seen_names[$dependency_name]}" >&2
-        echo "  $dependency_path" >&2
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --formats)
+      FORMATS="${2:-}"
+      if [[ -z "$FORMATS" ]]; then
+        echo "error: --formats requires a comma-separated value" >&2
         exit 1
       fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
 
-      seen_paths["$dependency_path"]=1
-      seen_names["$dependency_name"]="$dependency_path"
-
-      echo "Bundling Linux dependency $dependency_name from $dependency_path" >&2
-      cp -L "$dependency_path" "$PACKAGE_LIB_DIR/$dependency_name"
-      chmod 755 "$PACKAGE_LIB_DIR/$dependency_name"
-      queue+=("$dependency_path")
-    done < <(list_linux_runtime_dependencies "$current")
-  done
-}
-
-patch_linux_runtime_paths() {
-  local binary_path="$1"
-  local libs_dir="$2"
-  local binary_rpath="$3"
-
-  patchelf --set-rpath "$binary_rpath" "$binary_path"
-
-  if [[ -d "$libs_dir" ]]; then
-    while IFS= read -r -d '' library_path; do
-      patchelf --set-rpath '$ORIGIN' "$library_path"
-    done < <(find "$libs_dir" -maxdepth 1 -type f -name '*.so*' -print0)
-  fi
-}
-
-validate_linux_runtime_bundle() {
-  local binary_path="$1"
-  local libs_dir="$2"
-  local ldd_output
-
-  ldd_output="$(env LD_LIBRARY_PATH="$libs_dir" ldd "$binary_path")"
-  if grep -Fq "not found" <<<"$ldd_output"; then
-    echo "error: bundled Linux runtime dependencies are incomplete for $binary_path" >&2
-    echo "$ldd_output" >&2
-    exit 1
-  fi
-}
-
-echo "Downloading bundled Codex runtime for Linux..." >&2
-"$ROOT_DIR/scripts/download_codex_runtime_unix.sh" linux >/dev/null
-echo "Validating bundled Codex runtime for Linux..." >&2
-"$ROOT_DIR/scripts/validate_codex_runtime_bundle.sh" --strict --platform linux >/dev/null
-echo "Building Linux release binary..." >&2
-(
-  cd "$ROOT_DIR"
-  export CARGO_TARGET_DIR="$TARGET_DIR"
-  "$ROOT_DIR/scripts/build_linux.sh" --target "$TARGET_TRIPLE"
-)
-
-if ! command -v patchelf >/dev/null 2>&1; then
-  echo "error: patchelf is required to bundle Linux shared libraries" >&2
-  exit 1
+if [[ ",$FORMATS," == *",all,"* ]]; then
+  FORMATS="appimage,tarball,deb,rpm"
 fi
 
-rm -rf "$PACKAGE_DIR" "$ARCHIVE_PATH" "$APPIMAGE_PATH"
-mkdir -p "$PACKAGE_DIR/codex-runtime/linux"
-mkdir -p "$PACKAGE_LIB_DIR"
+build_tarball=0
+build_appimage=0
+build_deb=0
+build_rpm=0
 
-cp "$BINARY_SOURCE_PATH" "$PACKAGED_BINARY_PATH"
-cp "$LAUNCHER_SOURCE_PATH" "$PACKAGED_LAUNCHER_PATH"
-cp "$CODEX_SOURCE_PATH" "$PACKAGED_CODEX_PATH"
-chmod +x "$PACKAGED_BINARY_PATH" "$PACKAGED_LAUNCHER_PATH" "$PACKAGED_CODEX_PATH"
+IFS=',' read -r -a requested_formats <<<"$FORMATS"
+for requested_format in "${requested_formats[@]}"; do
+  case "$requested_format" in
+    appimage)
+      build_appimage=1
+      ;;
+    tarball)
+      build_tarball=1
+      ;;
+    deb)
+      build_deb=1
+      ;;
+    rpm)
+      build_rpm=1
+      ;;
+    "")
+      ;;
+    *)
+      echo "error: unknown Linux package format '$requested_format'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
 
-echo "Bundling Linux shared libraries into tarball fallback..." >&2
-bundle_linux_runtime_dependencies "$BINARY_SOURCE_PATH"
-patch_linux_runtime_paths "$PACKAGED_BINARY_PATH" "$PACKAGE_LIB_DIR" '$ORIGIN/lib'
-validate_linux_runtime_bundle "$PACKAGED_BINARY_PATH" "$PACKAGE_LIB_DIR"
-"$ROOT_DIR/scripts/validate_release_bundle_layout.sh" linux-package "$PACKAGE_DIR"
+prepare_linux_release_bundle
 
-mkdir -p "$DIST_DIR"
-tar -C "$DIST_DIR" -czf "$ARCHIVE_PATH" "$(basename "$PACKAGE_DIR")"
+artifact_paths=()
 
-echo "Building Linux AppImage package..." >&2
-build_linux_appimage
-chmod +x "$APPIMAGE_PATH"
+if [[ "$build_tarball" == "1" ]]; then
+  rm -f "$ARCHIVE_PATH"
+  tar -C "$(dirname "$PACKAGE_DIR")" -czf "$ARCHIVE_PATH" "$(basename "$PACKAGE_DIR")"
+  echo "Created Linux tarball artifact at $ARCHIVE_PATH" >&2
+  artifact_paths+=("$ARCHIVE_PATH")
+fi
 
-echo "Created Linux AppImage artifact at $APPIMAGE_PATH" >&2
-echo "Created Linux release artifact at $ARCHIVE_PATH" >&2
+if [[ "$build_appimage" == "1" ]]; then
+  rm -f "$APPIMAGE_PATH"
+  echo "Building Linux AppImage package..." >&2
+  build_linux_appimage
+  echo "Created Linux AppImage artifact at $APPIMAGE_PATH" >&2
+  artifact_paths+=("$APPIMAGE_PATH")
+fi
 
-printf '%s\n' "$APPIMAGE_PATH"
+if [[ "$build_deb" == "1" || "$build_rpm" == "1" ]]; then
+  prepare_linux_system_install_root
+fi
+
+if [[ "$build_deb" == "1" ]]; then
+  build_linux_deb_package
+  artifact_paths+=("$DEB_PATH")
+fi
+
+if [[ "$build_rpm" == "1" ]]; then
+  build_linux_rpm_package
+  artifact_paths+=("$RPM_PATH")
+fi
+
+printf '%s\n' "${artifact_paths[@]}"

--- a/scripts/smoke_test_linux_system_package.sh
+++ b/scripts/smoke_test_linux_system_package.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/linux_release_common.sh"
+init_linux_release_paths
+
+usage() {
+  cat <<'EOF'
+Smoke-test Linux system packages in a container.
+
+Usage:
+  ./scripts/smoke_test_linux_system_package.sh <deb|rpm> [package-path]
+EOF
+}
+
+detect_container_runner() {
+  if command -v docker >/dev/null 2>&1; then
+    printf '%s\n' "docker"
+    return 0
+  fi
+
+  if command -v podman >/dev/null 2>&1; then
+    printf '%s\n' "podman"
+    return 0
+  fi
+
+  return 1
+}
+
+run_deb_smoke_test() {
+  local package_path="$1"
+  local runner="$2"
+  local image="${HUNK_DEB_SMOKE_TEST_IMAGE:-ubuntu:24.04}"
+  local package_dir package_name
+
+  package_dir="$(dirname "$package_path")"
+  package_name="$(basename "$package_path")"
+
+  "$runner" run --rm \
+    -v "$package_dir:/artifacts:ro" \
+    "$image" \
+    /bin/bash -lc "
+      set -euo pipefail
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y /artifacts/$package_name
+      test -x /usr/bin/$PACKAGE_NAME
+      test -x /usr/lib/$PACKAGE_NAME/$REAL_BINARY_NAME
+      ldd /usr/lib/$PACKAGE_NAME/$REAL_BINARY_NAME | tee /tmp/hunk-ldd.txt
+      if grep -Fq 'not found' /tmp/hunk-ldd.txt; then
+        echo 'error: unresolved runtime dependency after Debian install' >&2
+        exit 1
+      fi
+    "
+}
+
+run_rpm_smoke_test() {
+  local package_path="$1"
+  local runner="$2"
+  local image="${HUNK_RPM_SMOKE_TEST_IMAGE:-fedora:latest}"
+  local package_dir package_name
+
+  package_dir="$(dirname "$package_path")"
+  package_name="$(basename "$package_path")"
+
+  "$runner" run --rm \
+    -v "$package_dir:/artifacts:ro" \
+    "$image" \
+    /bin/bash -lc "
+      set -euo pipefail
+      dnf install -y /artifacts/$package_name
+      test -x /usr/bin/$PACKAGE_NAME
+      test -x /usr/lib/$PACKAGE_NAME/$REAL_BINARY_NAME
+      ldd /usr/lib/$PACKAGE_NAME/$REAL_BINARY_NAME | tee /tmp/hunk-ldd.txt
+      if grep -Fq 'not found' /tmp/hunk-ldd.txt; then
+        echo 'error: unresolved runtime dependency after RPM install' >&2
+        exit 1
+      fi
+    "
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+format="$1"
+package_path="${2:-}"
+runner="$(detect_container_runner || true)"
+if [[ -z "$runner" ]]; then
+  echo "error: install Docker or Podman to run Linux package smoke tests" >&2
+  exit 1
+fi
+
+case "$format" in
+  deb)
+    package_path="${package_path:-$DEB_PATH}"
+    if [[ ! -f "$package_path" ]]; then
+      echo "error: Debian package not found at $package_path" >&2
+      echo "hint: run ./scripts/package_linux_release.sh --formats deb first" >&2
+      exit 1
+    fi
+    run_deb_smoke_test "$package_path" "$runner"
+    ;;
+  rpm)
+    package_path="${package_path:-$RPM_PATH}"
+    if [[ ! -f "$package_path" ]]; then
+      echo "error: RPM package not found at $package_path" >&2
+      echo "hint: run ./scripts/package_linux_release.sh --formats rpm first" >&2
+      exit 1
+    fi
+    run_rpm_smoke_test "$package_path" "$runner"
+    ;;
+  *)
+    echo "error: unknown package format '$format'" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+echo "Linux $format smoke test passed for $package_path" >&2

--- a/scripts/validate_release_bundle_layout.sh
+++ b/scripts/validate_release_bundle_layout.sh
@@ -6,7 +6,7 @@ usage() {
 Validate packaged release bundle layouts.
 
 Usage:
-  ./scripts/validate_release_bundle_layout.sh <macos-app|linux-package|linux-appdir> <path>
+  ./scripts/validate_release_bundle_layout.sh <macos-app|linux-package|linux-appdir|linux-install-root> <path>
 EOF
 }
 
@@ -76,6 +76,22 @@ validate_linux_appdir() {
   forbid_helix_paths "$appdir_path"
 }
 
+validate_linux_install_root() {
+  local install_root="$1"
+
+  require_executable "$install_root/usr/bin/hunk-desktop" "Linux installed launcher wrapper"
+  require_executable "$install_root/usr/bin/hunk_desktop" "Linux installed launcher alias"
+  require_executable "$install_root/usr/lib/hunk-desktop/hunk_desktop_bin" "Linux installed binary"
+  require_executable "$install_root/usr/lib/hunk-desktop/hunk-desktop" "Linux installed private launcher"
+  require_executable \
+    "$install_root/usr/lib/hunk-desktop/codex-runtime/linux/codex" \
+    "Linux installed bundled Codex runtime"
+  require_path "$install_root/usr/lib/hunk-desktop/lib" "Linux installed shared library directory"
+  require_path "$install_root/usr/share/applications/hunk-desktop.desktop" "Linux desktop entry"
+  require_path "$install_root/usr/share/icons/hicolor/1024x1024/apps/hunk-desktop.png" "Linux desktop icon"
+  forbid_helix_paths "$install_root"
+}
+
 if [[ $# -ne 2 ]]; then
   usage >&2
   exit 1
@@ -93,6 +109,9 @@ case "$mode" in
     ;;
   linux-appdir)
     validate_linux_appdir "$bundle_path"
+    ;;
+  linux-install-root)
+    validate_linux_install_root "$bundle_path"
     ;;
   *)
     echo "error: unknown validation mode '$mode'" >&2


### PR DESCRIPTION
Refactors `scripts/package_linux_release.sh` to support format-selective builds (`--formats`) for AppImage/tarball/DEB/RPM, adds Just targets for per-format packaging and containerized DEB/RPM smoke tests, and extends release/adhoc workflows to install RPM tooling and upload DEB/RPM artifacts alongside AppImage/tarball outputs.