### PR TITLE
feat: toggle sidebar by hitting cmd+1 while already on file view

### DIFF
--- a/crates/hunk-desktop/src/app/controller/file_tree.rs
+++ b/crates/hunk-desktop/src/app/controller/file_tree.rs
@@ -166,7 +166,13 @@ impl DiffViewer {
         cx: &mut Context<Self>,
     ) {
         self.focus_handle.focus(window, cx);
-        self.set_workspace_view_mode(WorkspaceSwitchAction::Files.target_mode(), cx);
+        let action = WorkspaceSwitchAction::Files;
+        if action.toggles_sidebar_when_repeated(self.workspace_view_mode) {
+            self.toggle_active_sidebar(cx);
+            return;
+        }
+
+        self.set_workspace_view_mode(action.target_mode(), cx);
     }
 
     pub(super) fn switch_to_review_view_action(

--- a/crates/hunk-desktop/src/app/workspace_view.rs
+++ b/crates/hunk-desktop/src/app/workspace_view.rs
@@ -95,4 +95,14 @@ impl WorkspaceSwitchAction {
             Self::Ai => WorkspaceViewMode::Ai,
         }
     }
+
+    pub(super) const fn toggles_sidebar_when_repeated(
+        self,
+        current_mode: WorkspaceViewMode,
+    ) -> bool {
+        matches!(
+            (self, current_mode),
+            (Self::Files, WorkspaceViewMode::Files)
+        )
+    }
 }

--- a/crates/hunk-desktop/tests/workspace_view_modes.rs
+++ b/crates/hunk-desktop/tests/workspace_view_modes.rs
@@ -43,6 +43,17 @@ fn ai_controller_switch_action_targets_ai_mode() {
 }
 
 #[test]
+fn repeated_files_shortcut_toggles_sidebar_only_in_files_mode() {
+    assert!(WorkspaceSwitchAction::Files.toggles_sidebar_when_repeated(WorkspaceViewMode::Files));
+    assert!(!WorkspaceSwitchAction::Files.toggles_sidebar_when_repeated(WorkspaceViewMode::Diff));
+    assert!(!WorkspaceSwitchAction::Review.toggles_sidebar_when_repeated(WorkspaceViewMode::Diff));
+    assert!(
+        !WorkspaceSwitchAction::Git.toggles_sidebar_when_repeated(WorkspaceViewMode::GitWorkspace)
+    );
+    assert!(!WorkspaceSwitchAction::Ai.toggles_sidebar_when_repeated(WorkspaceViewMode::Ai));
+}
+
+#[test]
 fn only_review_mode_enables_diff_stream() {
     assert!(!WorkspaceViewMode::Ai.supports_sidebar_tree());
     assert!(!WorkspaceViewMode::Ai.supports_diff_stream());


### PR DESCRIPTION
Let's you open the side bar by repeatedly hitting the file view