### PR TITLE
Recover workspace when the current project disappears

### DIFF
--- a/crates/hunk-desktop/src/app.rs
+++ b/crates/hunk-desktop/src/app.rs
@@ -178,6 +178,7 @@ mod fuzzy_match;
 mod project_open;
 mod project_picker;
 mod refresh_policy;
+mod repo_discovery;
 mod review_compare_picker;
 mod workspace_target_picker;
 

--- a/crates/hunk-desktop/src/app/controller/core_snapshot.rs
+++ b/crates/hunk-desktop/src/app/controller/core_snapshot.rs
@@ -831,7 +831,69 @@ impl DiffViewer {
             cx.notify();
             return;
         }
-        self.reset_to_empty_workspace_state(true, cx);
+        self.recover_from_missing_workspace_project(cx);
+    }
+
+    fn recover_from_missing_workspace_project(&mut self, cx: &mut Context<Self>) {
+        let unavailable_project_path = self
+            .project_path
+            .clone()
+            .or_else(|| self.state.active_project_path().cloned());
+        let removed_from_workspace = unavailable_project_path
+            .as_ref()
+            .is_some_and(|project_path| self.state.remove_workspace_project(project_path.as_path()));
+
+        if removed_from_workspace {
+            self.persist_state();
+        }
+
+        if let Some(project_path) = unavailable_project_path.as_ref() {
+            self.clear_workspace_project_caches(project_path.as_path());
+            self.discard_workspace_project_state(project_path.as_path());
+            self.discard_files_terminal_state_for_project(
+                project_path.as_path(),
+                "removing unavailable project from workspace",
+            );
+            self.remove_ai_workspace_states_for_project(project_path.as_path(), cx);
+        }
+
+        self.invalidate_ai_visible_frame_state_with_reason("refresh");
+        self.project_path = None;
+        self.repo_root = None;
+
+        let next_active_project = self.state.active_project_path().cloned();
+        if let Some(next_active_project) = next_active_project {
+            let next_project_name =
+                crate::app::project_picker::project_display_name(next_active_project.as_path());
+            self.activate_workspace_project_root(next_active_project, cx);
+            self.git_status_message = Some(format!(
+                "Previous project is unavailable. Switched to '{}'.",
+                next_project_name
+            ));
+            return;
+        }
+
+        self.reset_to_empty_workspace_state(false, cx);
+        self.git_status_message =
+            Some("Previous project is unavailable. Open another project.".to_string());
+    }
+
+    fn clear_workspace_project_caches(&mut self, project_path: &std::path::Path) {
+        let cache_key = project_path.to_string_lossy().to_string();
+        let removed_workflow = self
+            .state
+            .git_workflow_cache_by_repo
+            .remove(cache_key.as_str())
+            .is_some();
+        let removed_recent = self
+            .state
+            .git_recent_commits_cache_by_repo
+            .remove(cache_key.as_str())
+            .is_some();
+
+        if removed_workflow || removed_recent {
+            self.persist_state();
+        }
     }
 
     fn format_error_chain(err: &anyhow::Error) -> String {
@@ -849,10 +911,6 @@ impl DiffViewer {
     }
 
     fn is_missing_repository_error(err: &anyhow::Error) -> bool {
-        err.chain().any(|cause| {
-            let message = cause.to_string();
-            message.contains("failed to discover git repository")
-                || message.contains("could not find repository")
-        })
+        crate::app::repo_discovery::is_missing_repository_error(err)
     }
 }

--- a/crates/hunk-desktop/src/app/repo_discovery.rs
+++ b/crates/hunk-desktop/src/app/repo_discovery.rs
@@ -1,0 +1,8 @@
+pub(crate) fn is_missing_repository_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        let message = cause.to_string().to_ascii_lowercase();
+        message.contains("failed to discover git repository")
+            || message.contains("could not find repository")
+            || message.contains("not a git repository")
+    })
+}

--- a/crates/hunk-desktop/tests/repo_discovery.rs
+++ b/crates/hunk-desktop/tests/repo_discovery.rs
@@ -1,0 +1,18 @@
+#[path = "../src/app/repo_discovery.rs"]
+mod repo_discovery;
+
+use anyhow::anyhow;
+
+#[test]
+fn missing_repository_error_detection_is_case_insensitive() {
+    let err = anyhow!("failed to discover Git repository from /tmp/hunk");
+
+    assert!(repo_discovery::is_missing_repository_error(&err));
+}
+
+#[test]
+fn missing_repository_error_detection_matches_non_repo_messages() {
+    let err = anyhow!("not a git repository");
+
+    assert!(repo_discovery::is_missing_repository_error(&err));
+}


### PR DESCRIPTION
Handle missing repository/project state by clearing cached workspace data, switching to the next available project when possible, and surfacing a clear status message instead of leaving the viewer stranded.