### PR TITLE
Build surfaced two missing imports: the new progress-step helper wasn’t

### DIFF
--- a/crates/hunk-desktop/src/app/ai_git_progress.rs
+++ b/crates/hunk-desktop/src/app/ai_git_progress.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AiGitProgressAction {
     CommitAndPush,
+    CreateBranchAndPush,
     WorkspaceCommitAndPush,
     OpenPr,
     DeleteWorktree,
@@ -10,6 +11,7 @@ impl AiGitProgressAction {
     pub(crate) const fn title(self) -> &'static str {
         match self {
             Self::CommitAndPush | Self::WorkspaceCommitAndPush => "Commit and Push",
+            Self::CreateBranchAndPush => "Create Branch and Push",
             Self::OpenPr => "Open PR",
             Self::DeleteWorktree => "Delete Worktree",
         }
@@ -18,6 +20,9 @@ impl AiGitProgressAction {
     pub(crate) const fn summary(self) -> &'static str {
         match self {
             Self::CommitAndPush => "Publishing the current AI thread to the active branch.",
+            Self::CreateBranchAndPush => {
+                "Creating a new branch for the current AI thread, generating a commit message, creating a commit, and pushing the new branch."
+            }
             Self::WorkspaceCommitAndPush => {
                 "Staging changed files, generating a commit message, creating a commit, and pushing the active branch."
             }
@@ -47,8 +52,8 @@ impl AiGitProgressStep {
     pub(crate) const fn label(self) -> &'static str {
         match self {
             Self::StagingFiles => "Staging files...",
-            Self::GeneratingBranchName => "Generating review branch name...",
-            Self::CreatingReviewBranch => "Creating review branch...",
+            Self::GeneratingBranchName => "Generating branch name...",
+            Self::CreatingReviewBranch => "Creating branch...",
             Self::GeneratingCommitMessage => "Generating commit message...",
             Self::CreatingCommit => "Creating commit...",
             Self::PushingBranch => "Pushing branch...",
@@ -94,6 +99,16 @@ impl AiGitProgressState {
 
 pub(crate) fn ai_commit_and_push_progress_steps() -> Vec<AiGitProgressStep> {
     vec![
+        AiGitProgressStep::GeneratingCommitMessage,
+        AiGitProgressStep::CreatingCommit,
+        AiGitProgressStep::PushingBranch,
+    ]
+}
+
+pub(crate) fn ai_create_branch_and_push_progress_steps() -> Vec<AiGitProgressStep> {
+    vec![
+        AiGitProgressStep::GeneratingBranchName,
+        AiGitProgressStep::CreatingReviewBranch,
         AiGitProgressStep::GeneratingCommitMessage,
         AiGitProgressStep::CreatingCommit,
         AiGitProgressStep::PushingBranch,

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
@@ -903,6 +903,7 @@ impl DiffViewer {
                     );
                     let new_branch_name = activate_new_ai_review_branch(
                         repo_root.as_path(),
+                        branch_name.as_str(),
                         requested_branch_name.as_str(),
                     )?;
 
@@ -1117,6 +1118,7 @@ impl DiffViewer {
                         );
                         activate_new_ai_review_branch(
                             repo_root.as_path(),
+                            branch_name.as_str(),
                             requested_branch_name.as_str(),
                         )?
                     } else {

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
@@ -617,6 +617,249 @@ impl DiffViewer {
         );
     }
 
+    pub(super) fn ai_create_branch_and_push_for_current_thread(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(reason) = self.ai_publish_blocker().filter(|reason| !reason.is_empty()) {
+            let message = format!("Create branch and push unavailable: {reason}");
+            self.git_status_message = Some(message.clone());
+            Self::push_warning_notification(message, Some(window), cx);
+            cx.notify();
+            return;
+        }
+
+        let context = match self.ai_current_thread_git_action_context("creating a branch") {
+            Ok(context) => context,
+            Err(reason) => {
+                let message = format!("Create branch and push unavailable: {reason}");
+                self.git_status_message = Some(message.clone());
+                Self::push_warning_notification(message, Some(window), cx);
+                cx.notify();
+                return;
+            }
+        };
+
+        if ai_create_branch_and_push_strategy(context.repo_root.as_path(), context.branch_name.as_str())
+            == AiCreateBranchAndPushStrategy::CreateBranchImmediately
+        {
+            self.ai_run_create_branch_and_push_action(context, cx);
+            return;
+        }
+
+        let branch_name = context.branch_name.clone();
+        let view = cx.entity();
+
+        gpui_component::WindowExt::open_alert_dialog(window, cx, move |alert, _, cx| {
+            alert
+                .width(px(520.0))
+                .title("Choose Push Target")
+                .description(format!(
+                    "You're already on branch '{}'. Create a fresh branch for this AI thread, or push the current branch instead?",
+                    branch_name
+                ))
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(cx.theme().muted_foreground)
+                        .whitespace_normal()
+                        .child(
+                            "Opening a PR later will reuse whichever branch you choose here.",
+                        ),
+                )
+                .footer(
+                    DialogFooter::new()
+                        .child(
+                            DialogClose::new()
+                                .child(Button::new("ai-create-branch-and-push-cancel").label("Cancel").outline()),
+                        )
+                        .child(
+                            Button::new("ai-push-current-branch")
+                                .label(format!("Push {}", branch_name))
+                                .outline()
+                                .on_click({
+                                    let view = view.clone();
+                                    move |_, window, cx| {
+                                        window.close_dialog(cx);
+                                        view.update(cx, |this, cx| {
+                                            this.ai_commit_and_push_for_current_thread(cx);
+                                        });
+                                    }
+                                }),
+                        )
+                        .child(
+                            DialogAction::new().child(
+                                Button::new("ai-create-and-push-new-branch")
+                                    .label("Create New Branch")
+                                    .primary(),
+                            ),
+                        ),
+                )
+                .on_ok({
+                    let view = view.clone();
+                    let context = context.clone();
+                    move |_, _, cx| {
+                        view.update(cx, |this, cx| {
+                            this.ai_run_create_branch_and_push_action(context.clone(), cx);
+                        });
+                        true
+                    }
+                })
+        });
+    }
+
+    fn ai_run_create_branch_and_push_action(
+        &mut self,
+        context: AiThreadGitActionContext,
+        cx: &mut Context<Self>,
+    ) {
+        let fallback_commit_message = ai_commit_message_for_thread(
+            &self.ai_state_snapshot,
+            context.thread_id.as_str(),
+            context.branch_name.as_str(),
+        );
+        let fallback_new_branch_name = ai_branch_name_for_thread(
+            &self.ai_state_snapshot,
+            context.thread_id.as_str(),
+            context.branch_name.as_str(),
+            false,
+        );
+        let branch_generation_seed = ai_branch_generation_seed_for_thread(
+            &self.ai_state_snapshot,
+            context.thread_id.as_str(),
+            context.branch_name.as_str(),
+        );
+        let codex_executable = Self::resolve_codex_executable_path();
+        let repo_root = context.repo_root.clone();
+        let branch_name = context.branch_name.clone();
+        let epoch = self.begin_git_action("Create Branch and Push", cx);
+        self.begin_ai_git_progress(
+            epoch,
+            AiGitProgressAction::CreateBranchAndPush,
+            ai_create_branch_and_push_progress_steps(),
+            AiGitProgressStep::GeneratingBranchName,
+            Some(ai_branch_progress_detail("Current branch", branch_name.as_str())),
+            cx,
+        );
+        self.spawn_ai_git_action_with_progress(
+            epoch,
+            cx,
+            move |progress_tx| {
+                (|| -> anyhow::Result<(Option<String>, String)> {
+                    let requested_branch_name = try_ai_branch_name_for_prompt(
+                        codex_executable.as_path(),
+                        repo_root.as_path(),
+                        branch_generation_seed.as_str(),
+                        &[],
+                        false,
+                    )
+                    .unwrap_or_else(|| fallback_new_branch_name.clone());
+                    send_ai_git_progress(
+                        &progress_tx,
+                        AiGitProgressStep::CreatingReviewBranch,
+                        Some(ai_branch_progress_detail(
+                            "New branch",
+                            requested_branch_name.as_str(),
+                        )),
+                    );
+                    let new_branch_name = activate_new_ai_review_branch(
+                        repo_root.as_path(),
+                        requested_branch_name.as_str(),
+                    )?;
+
+                    send_ai_git_progress(
+                        &progress_tx,
+                        AiGitProgressStep::GeneratingCommitMessage,
+                        Some(ai_branch_progress_detail("New branch", new_branch_name.as_str())),
+                    );
+                    let commit_message = resolve_ai_commit_message_for_working_copy(
+                        AiCodexGenerationConfig {
+                            codex_executable: codex_executable.as_path(),
+                            repo_root: repo_root.as_path(),
+                        },
+                        repo_root.as_path(),
+                        new_branch_name.as_str(),
+                        &fallback_commit_message,
+                    );
+                    send_ai_git_progress(
+                        &progress_tx,
+                        AiGitProgressStep::CreatingCommit,
+                        Some(ai_commit_progress_detail(commit_message.subject.as_str())),
+                    );
+                    let commit_message_text = commit_message.as_git_message();
+                    let committed_subject = match commit_staged_with_details(
+                        repo_root.as_path(),
+                        commit_message_text.as_str(),
+                    ) {
+                        Ok(created) => Some(created.subject),
+                        Err(err) if err.to_string().contains("no changes to commit") => None,
+                        Err(err) => return Err(err),
+                    };
+
+                    send_ai_git_progress(
+                        &progress_tx,
+                        AiGitProgressStep::PushingBranch,
+                        Some(ai_branch_progress_detail("New branch", new_branch_name.as_str())),
+                    );
+                    push_current_branch_with_publish_fallback(
+                        repo_root.as_path(),
+                        new_branch_name.as_str(),
+                    )?;
+
+                    Ok((committed_subject, new_branch_name))
+                })()
+            },
+            move |this, result, execution_elapsed, total_elapsed, cx| {
+                if epoch != this.git_action_epoch {
+                    return;
+                }
+
+                this.finish_git_action();
+                match result {
+                    Ok((committed_subject, branch_name)) => {
+                        debug!(
+                            "git action complete: epoch={} action=Create Branch and Push exec_elapsed_ms={} total_elapsed_ms={} branch={}",
+                            epoch,
+                            execution_elapsed.as_millis(),
+                            total_elapsed.as_millis(),
+                            branch_name
+                        );
+                        let committed = committed_subject.is_some();
+                        if let Some(subject) = committed_subject {
+                            this.last_commit_subject = Some(subject);
+                        }
+                        this.request_snapshot_refresh_workflow_only(true, cx);
+                        this.request_recent_commits_refresh(true, cx);
+                        let message = if committed {
+                            format!("Created, committed, and pushed {}", branch_name)
+                        } else {
+                            format!("Created and pushed {}", branch_name)
+                        };
+                        this.git_status_message = Some(message.clone());
+                        Self::push_success_notification(message, cx);
+                    }
+                    Err(err) => {
+                        error!(
+                            "git action failed: epoch={} action=Create Branch and Push exec_elapsed_ms={} total_elapsed_ms={} err={err:#}",
+                            epoch,
+                            execution_elapsed.as_millis(),
+                            total_elapsed.as_millis()
+                        );
+                        let summary = err.to_string();
+                        this.git_status_message = Some(format!("Git error: {err:#}"));
+                        Self::push_error_notification(
+                            format!("Create Branch and Push failed: {summary}"),
+                            cx,
+                        );
+                    }
+                }
+
+                cx.notify();
+            },
+        );
+    }
+
     pub(super) fn ai_open_pr_for_current_thread(&mut self, cx: &mut Context<Self>) {
         if let Some(reason) = self.ai_open_pr_blocker().filter(|reason| !reason.is_empty()) {
             let message = format!("Open PR unavailable: {reason}");

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
@@ -59,10 +59,10 @@ impl AiBranchTargetChoiceAction {
         }
     }
 
-    fn current_branch_button_label(self, branch_name: &str) -> String {
+    fn current_branch_button_label(self) -> String {
         match self {
-            Self::CreateBranchAndPush => format!("Push {}", branch_name),
-            Self::OpenPr => format!("Open PR on {}", branch_name),
+            Self::CreateBranchAndPush => "Push Current Branch".to_string(),
+            Self::OpenPr => "Open PR on Current Branch".to_string(),
         }
     }
 
@@ -710,13 +710,13 @@ impl DiffViewer {
         let title = action.dialog_title();
         let description = action.dialog_description(branch_name.as_str());
         let hint_text = action.hint_text();
-        let current_branch_button_label = action.current_branch_button_label(branch_name.as_str());
+        let current_branch_button_label = action.current_branch_button_label();
         let new_branch_button_label = action.new_branch_button_label();
         let view = cx.entity();
 
         gpui_component::WindowExt::open_alert_dialog(window, cx, move |alert, _, cx| {
             alert
-                .width(px(520.0))
+                .width(px(600.0))
                 .title(title)
                 .description(description.clone())
                 .child(
@@ -728,67 +728,83 @@ impl DiffViewer {
                 )
                 .footer(
                     DialogFooter::new()
+                        .w_full()
+                        .justify_between()
+                        .items_start()
+                        .gap_3()
                         .child(
-                            DialogClose::new().child(
-                                Button::new(action.cancel_button_id())
-                                    .label("Cancel")
-                                    .outline(),
-                            ),
-                        )
-                        .child(
-                            Button::new(action.current_branch_button_id())
-                                .label(current_branch_button_label.clone())
+                            Button::new(action.cancel_button_id())
+                                .label("Cancel")
                                 .outline()
-                                .on_click({
-                                    let view = view.clone();
-                                    let context = context.clone();
-                                    move |_, window, cx| {
-                                        window.close_dialog(cx);
-                                        view.update(cx, |this, cx| match action {
-                                            AiBranchTargetChoiceAction::CreateBranchAndPush => {
-                                                this.ai_run_commit_and_push_action(
-                                                    context.clone(),
-                                                    cx,
-                                                );
-                                            }
-                                            AiBranchTargetChoiceAction::OpenPr => {
-                                                this.ai_run_open_pr_action(
-                                                    context.clone(),
-                                                    AiOpenPrBranchStrategy::ReuseCurrentBranch,
-                                                    cx,
-                                                );
-                                            }
-                                        });
-                                    }
+                                .on_click(|_, window, cx| {
+                                    window.close_dialog(cx);
                                 }),
                         )
                         .child(
-                            DialogAction::new().child(
-                                Button::new(action.new_branch_button_id())
-                                    .label(new_branch_button_label)
-                                    .primary(),
-                            ),
+                            div()
+                                .h_flex()
+                                .flex_1()
+                                .min_w_0()
+                                .justify_end()
+                                .items_start()
+                                .gap_2()
+                                .flex_wrap()
+                                .child(
+                                    Button::new(action.current_branch_button_id())
+                                        .label(current_branch_button_label.clone())
+                                        .outline()
+                                        .on_click({
+                                            let view = view.clone();
+                                            let context = context.clone();
+                                            move |_, window, cx| {
+                                                window.close_dialog(cx);
+                                                view.update(cx, |this, cx| match action {
+                                                    AiBranchTargetChoiceAction::CreateBranchAndPush => {
+                                                        this.ai_run_commit_and_push_action(
+                                                            context.clone(),
+                                                            cx,
+                                                        );
+                                                    }
+                                                    AiBranchTargetChoiceAction::OpenPr => {
+                                                        this.ai_run_open_pr_action(
+                                                            context.clone(),
+                                                            AiOpenPrBranchStrategy::ReuseCurrentBranch,
+                                                            cx,
+                                                        );
+                                                    }
+                                                });
+                                            }
+                                        }),
+                                )
+                                .child(
+                                    Button::new(action.new_branch_button_id())
+                                        .label(new_branch_button_label)
+                                        .primary()
+                                        .on_click({
+                                            let view = view.clone();
+                                            let context = context.clone();
+                                            move |_, window, cx| {
+                                                window.close_dialog(cx);
+                                                view.update(cx, |this, cx| match action {
+                                                    AiBranchTargetChoiceAction::CreateBranchAndPush => {
+                                                        this.ai_run_create_branch_and_push_action(
+                                                            context.clone(),
+                                                            cx,
+                                                        );
+                                                    }
+                                                    AiBranchTargetChoiceAction::OpenPr => {
+                                                        this.ai_run_open_pr_action(
+                                                            context.clone(),
+                                                            AiOpenPrBranchStrategy::CreateReviewBranch,
+                                                            cx,
+                                                        );
+                                                    }
+                                                });
+                                            }
+                                        }),
+                                ),
                         ),
                 )
-                .on_ok({
-                    let view = view.clone();
-                    let context = context.clone();
-                    move |_, _, cx| {
-                        view.update(cx, |this, cx| match action {
-                            AiBranchTargetChoiceAction::CreateBranchAndPush => {
-                                this.ai_run_create_branch_and_push_action(context.clone(), cx);
-                            }
-                            AiBranchTargetChoiceAction::OpenPr => {
-                                this.ai_run_open_pr_action(
-                                    context.clone(),
-                                    AiOpenPrBranchStrategy::CreateReviewBranch,
-                                    cx,
-                                );
-                            }
-                        });
-                        true
-                    }
-                })
         });
     }
 

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops.rs
@@ -21,6 +21,80 @@ struct AiGitProgressEvent {
     detail: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AiBranchTargetChoiceAction {
+    CreateBranchAndPush,
+    OpenPr,
+}
+
+impl AiBranchTargetChoiceAction {
+    const fn dialog_title(self) -> &'static str {
+        match self {
+            Self::CreateBranchAndPush => "Choose Push Target",
+            Self::OpenPr => "Choose PR Target",
+        }
+    }
+
+    fn dialog_description(self, branch_name: &str) -> String {
+        match self {
+            Self::CreateBranchAndPush => format!(
+                "You're already on branch '{}'. Create a fresh branch for this AI thread, or push the current branch instead?",
+                branch_name
+            ),
+            Self::OpenPr => format!(
+                "You're already on branch '{}'. Open a PR for the current branch, or create a fresh branch and open a PR from that instead?",
+                branch_name
+            ),
+        }
+    }
+
+    const fn hint_text(self) -> &'static str {
+        match self {
+            Self::CreateBranchAndPush => {
+                "Opening a PR later will reuse whichever branch you choose here."
+            }
+            Self::OpenPr => {
+                "Use the current branch if it already matches this thread. Create a new branch if you want to keep the existing branch separate."
+            }
+        }
+    }
+
+    fn current_branch_button_label(self, branch_name: &str) -> String {
+        match self {
+            Self::CreateBranchAndPush => format!("Push {}", branch_name),
+            Self::OpenPr => format!("Open PR on {}", branch_name),
+        }
+    }
+
+    const fn new_branch_button_label(self) -> &'static str {
+        match self {
+            Self::CreateBranchAndPush => "Create New Branch",
+            Self::OpenPr => "Create New Branch and Open PR",
+        }
+    }
+
+    const fn cancel_button_id(self) -> &'static str {
+        match self {
+            Self::CreateBranchAndPush => "ai-create-branch-and-push-cancel",
+            Self::OpenPr => "ai-open-pr-branch-choice-cancel",
+        }
+    }
+
+    const fn current_branch_button_id(self) -> &'static str {
+        match self {
+            Self::CreateBranchAndPush => "ai-push-current-branch",
+            Self::OpenPr => "ai-open-pr-current-branch",
+        }
+    }
+
+    const fn new_branch_button_id(self) -> &'static str {
+        match self {
+            Self::CreateBranchAndPush => "ai-create-and-push-new-branch",
+            Self::OpenPr => "ai-create-branch-and-open-pr",
+        }
+    }
+}
+
 impl DiffViewer {
     fn ai_current_thread_git_action_context(
         &self,
@@ -508,6 +582,14 @@ impl DiffViewer {
                 return;
             }
         };
+        self.ai_run_commit_and_push_action(context, cx);
+    }
+
+    fn ai_run_commit_and_push_action(
+        &mut self,
+        context: AiThreadGitActionContext,
+        cx: &mut Context<Self>,
+    ) {
         let fallback_commit_message = ai_commit_message_for_thread(
             &self.ai_state_snapshot,
             context.thread_id.as_str(),
@@ -617,6 +699,99 @@ impl DiffViewer {
         );
     }
 
+    fn ai_prompt_for_branch_target_choice(
+        &mut self,
+        window: &mut Window,
+        context: AiThreadGitActionContext,
+        action: AiBranchTargetChoiceAction,
+        cx: &mut Context<Self>,
+    ) {
+        let branch_name = context.branch_name.clone();
+        let title = action.dialog_title();
+        let description = action.dialog_description(branch_name.as_str());
+        let hint_text = action.hint_text();
+        let current_branch_button_label = action.current_branch_button_label(branch_name.as_str());
+        let new_branch_button_label = action.new_branch_button_label();
+        let view = cx.entity();
+
+        gpui_component::WindowExt::open_alert_dialog(window, cx, move |alert, _, cx| {
+            alert
+                .width(px(520.0))
+                .title(title)
+                .description(description.clone())
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(cx.theme().muted_foreground)
+                        .whitespace_normal()
+                        .child(hint_text),
+                )
+                .footer(
+                    DialogFooter::new()
+                        .child(
+                            DialogClose::new().child(
+                                Button::new(action.cancel_button_id())
+                                    .label("Cancel")
+                                    .outline(),
+                            ),
+                        )
+                        .child(
+                            Button::new(action.current_branch_button_id())
+                                .label(current_branch_button_label.clone())
+                                .outline()
+                                .on_click({
+                                    let view = view.clone();
+                                    let context = context.clone();
+                                    move |_, window, cx| {
+                                        window.close_dialog(cx);
+                                        view.update(cx, |this, cx| match action {
+                                            AiBranchTargetChoiceAction::CreateBranchAndPush => {
+                                                this.ai_run_commit_and_push_action(
+                                                    context.clone(),
+                                                    cx,
+                                                );
+                                            }
+                                            AiBranchTargetChoiceAction::OpenPr => {
+                                                this.ai_run_open_pr_action(
+                                                    context.clone(),
+                                                    AiOpenPrBranchStrategy::ReuseCurrentBranch,
+                                                    cx,
+                                                );
+                                            }
+                                        });
+                                    }
+                                }),
+                        )
+                        .child(
+                            DialogAction::new().child(
+                                Button::new(action.new_branch_button_id())
+                                    .label(new_branch_button_label)
+                                    .primary(),
+                            ),
+                        ),
+                )
+                .on_ok({
+                    let view = view.clone();
+                    let context = context.clone();
+                    move |_, _, cx| {
+                        view.update(cx, |this, cx| match action {
+                            AiBranchTargetChoiceAction::CreateBranchAndPush => {
+                                this.ai_run_create_branch_and_push_action(context.clone(), cx);
+                            }
+                            AiBranchTargetChoiceAction::OpenPr => {
+                                this.ai_run_open_pr_action(
+                                    context.clone(),
+                                    AiOpenPrBranchStrategy::CreateReviewBranch,
+                                    cx,
+                                );
+                            }
+                        });
+                        true
+                    }
+                })
+        });
+    }
+
     pub(super) fn ai_create_branch_and_push_for_current_thread(
         &mut self,
         window: &mut Window,
@@ -641,72 +816,19 @@ impl DiffViewer {
             }
         };
 
-        if ai_create_branch_and_push_strategy(context.repo_root.as_path(), context.branch_name.as_str())
-            == AiCreateBranchAndPushStrategy::CreateBranchImmediately
-        {
+        if ai_should_prompt_for_create_branch_and_push_target(
+            context.repo_root.as_path(),
+            context.branch_name.as_str(),
+        ) {
+            self.ai_prompt_for_branch_target_choice(
+                window,
+                context,
+                AiBranchTargetChoiceAction::CreateBranchAndPush,
+                cx,
+            );
+        } else {
             self.ai_run_create_branch_and_push_action(context, cx);
-            return;
         }
-
-        let branch_name = context.branch_name.clone();
-        let view = cx.entity();
-
-        gpui_component::WindowExt::open_alert_dialog(window, cx, move |alert, _, cx| {
-            alert
-                .width(px(520.0))
-                .title("Choose Push Target")
-                .description(format!(
-                    "You're already on branch '{}'. Create a fresh branch for this AI thread, or push the current branch instead?",
-                    branch_name
-                ))
-                .child(
-                    div()
-                        .text_xs()
-                        .text_color(cx.theme().muted_foreground)
-                        .whitespace_normal()
-                        .child(
-                            "Opening a PR later will reuse whichever branch you choose here.",
-                        ),
-                )
-                .footer(
-                    DialogFooter::new()
-                        .child(
-                            DialogClose::new()
-                                .child(Button::new("ai-create-branch-and-push-cancel").label("Cancel").outline()),
-                        )
-                        .child(
-                            Button::new("ai-push-current-branch")
-                                .label(format!("Push {}", branch_name))
-                                .outline()
-                                .on_click({
-                                    let view = view.clone();
-                                    move |_, window, cx| {
-                                        window.close_dialog(cx);
-                                        view.update(cx, |this, cx| {
-                                            this.ai_commit_and_push_for_current_thread(cx);
-                                        });
-                                    }
-                                }),
-                        )
-                        .child(
-                            DialogAction::new().child(
-                                Button::new("ai-create-and-push-new-branch")
-                                    .label("Create New Branch")
-                                    .primary(),
-                            ),
-                        ),
-                )
-                .on_ok({
-                    let view = view.clone();
-                    let context = context.clone();
-                    move |_, _, cx| {
-                        view.update(cx, |this, cx| {
-                            this.ai_run_create_branch_and_push_action(context.clone(), cx);
-                        });
-                        true
-                    }
-                })
-        });
     }
 
     fn ai_run_create_branch_and_push_action(
@@ -860,11 +982,15 @@ impl DiffViewer {
         );
     }
 
-    pub(super) fn ai_open_pr_for_current_thread(&mut self, cx: &mut Context<Self>) {
+    pub(super) fn ai_open_pr_for_current_thread(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(reason) = self.ai_open_pr_blocker().filter(|reason| !reason.is_empty()) {
             let message = format!("Open PR unavailable: {reason}");
             self.git_status_message = Some(message.clone());
-            Self::push_warning_notification(message, None, cx);
+            Self::push_warning_notification(message, Some(window), cx);
             cx.notify();
             return;
         }
@@ -874,11 +1000,33 @@ impl DiffViewer {
             Err(reason) => {
                 let message = format!("Open PR unavailable: {reason}");
                 self.git_status_message = Some(message.clone());
-                Self::push_warning_notification(message, None, cx);
+                Self::push_warning_notification(message, Some(window), cx);
                 cx.notify();
                 return;
             }
         };
+        if ai_should_prompt_for_open_pr_target(context.repo_root.as_path(), context.branch_name.as_str())
+        {
+            self.ai_prompt_for_branch_target_choice(
+                window,
+                context,
+                AiBranchTargetChoiceAction::OpenPr,
+                cx,
+            );
+            return;
+        }
+
+        let open_pr_branch_strategy =
+            ai_open_pr_branch_strategy(context.repo_root.as_path(), &context.branch_name);
+        self.ai_run_open_pr_action(context, open_pr_branch_strategy, cx);
+    }
+
+    fn ai_run_open_pr_action(
+        &mut self,
+        context: AiThreadGitActionContext,
+        open_pr_branch_strategy: AiOpenPrBranchStrategy,
+        cx: &mut Context<Self>,
+    ) {
         let fallback_commit_message = ai_commit_message_for_thread(
             &self.ai_state_snapshot,
             context.thread_id.as_str(),
@@ -902,7 +1050,6 @@ impl DiffViewer {
         let branch_name = context.branch_name.clone();
         let start_mode = context.start_mode;
         let epoch = self.begin_git_action("Open PR", cx);
-        let open_pr_branch_strategy = ai_open_pr_branch_strategy(repo_root.as_path(), &branch_name);
         let create_review_branch =
             open_pr_branch_strategy == AiOpenPrBranchStrategy::CreateReviewBranch;
         let branch_detail_label = if create_review_branch {

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
@@ -178,8 +178,18 @@ fn try_ai_commit_message_for_staged_index(
 
 fn activate_new_ai_review_branch(
     repo_root: &std::path::Path,
+    current_branch_name: &str,
     requested_branch_name: &str,
 ) -> anyhow::Result<String> {
+    let default_branch_name = resolve_default_base_branch_name(repo_root)
+        .context("failed to resolve the default branch for isolated AI branch creation")?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "unable to resolve the default branch needed to isolate this AI thread; push the current branch instead"
+            )
+        })?;
+    let create_from_default_branch = default_branch_name.trim() != current_branch_name.trim();
+
     let mut attempt = 0usize;
     loop {
         attempt = attempt.saturating_add(1);
@@ -188,11 +198,20 @@ fn activate_new_ai_review_branch(
         } else {
             format!("{requested_branch_name}-{attempt}")
         };
-        match checkout_or_create_branch_with_change_transfer(
-            repo_root,
-            candidate_branch_name.as_str(),
-            true,
-        ) {
+        let activation_result = if create_from_default_branch {
+            create_branch_from_base_with_change_transfer(
+                repo_root,
+                candidate_branch_name.as_str(),
+                default_branch_name.as_str(),
+            )
+        } else {
+            checkout_or_create_branch_with_change_transfer(
+                repo_root,
+                candidate_branch_name.as_str(),
+                true,
+            )
+        };
+        match activation_result {
             Ok(()) => return Ok(candidate_branch_name),
             Err(err) => {
                 if err.to_string().contains("already exists") && attempt < 20 {

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
@@ -29,6 +29,12 @@ enum AiOpenPrBranchStrategy {
     ReuseCurrentBranch,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AiCreateBranchAndPushStrategy {
+    CreateBranchImmediately,
+    PromptForPushTarget,
+}
+
 fn ai_open_pr_branch_strategy(
     repo_root: &std::path::Path,
     branch_name: &str,
@@ -47,6 +53,28 @@ fn ai_open_pr_branch_strategy_for_branch(
         AiOpenPrBranchStrategy::CreateReviewBranch
     } else {
         AiOpenPrBranchStrategy::ReuseCurrentBranch
+    }
+}
+
+fn ai_create_branch_and_push_strategy(
+    repo_root: &std::path::Path,
+    branch_name: &str,
+) -> AiCreateBranchAndPushStrategy {
+    let default_branch_name = resolve_default_base_branch_name(repo_root).ok().flatten();
+    ai_create_branch_and_push_strategy_for_branch(branch_name, default_branch_name.as_deref())
+}
+
+fn ai_create_branch_and_push_strategy_for_branch(
+    branch_name: &str,
+    default_branch_name: Option<&str>,
+) -> AiCreateBranchAndPushStrategy {
+    match ai_open_pr_branch_strategy_for_branch(branch_name, default_branch_name) {
+        AiOpenPrBranchStrategy::CreateReviewBranch => {
+            AiCreateBranchAndPushStrategy::CreateBranchImmediately
+        }
+        AiOpenPrBranchStrategy::ReuseCurrentBranch => {
+            AiCreateBranchAndPushStrategy::PromptForPushTarget
+        }
     }
 }
 
@@ -252,6 +280,30 @@ mod ai_git_ops_tests {
         assert_eq!(
             ai_open_pr_branch_strategy_for_branch("feature/ai-thread", None),
             AiOpenPrBranchStrategy::ReuseCurrentBranch
+        );
+    }
+
+    #[test]
+    fn create_branch_and_push_strategy_creates_immediately_for_default_branch() {
+        assert_eq!(
+            ai_create_branch_and_push_strategy_for_branch("main", Some("main")),
+            AiCreateBranchAndPushStrategy::CreateBranchImmediately
+        );
+    }
+
+    #[test]
+    fn create_branch_and_push_strategy_prompts_for_non_default_branch() {
+        assert_eq!(
+            ai_create_branch_and_push_strategy_for_branch("feature/ai-thread", Some("main")),
+            AiCreateBranchAndPushStrategy::PromptForPushTarget
+        );
+    }
+
+    #[test]
+    fn create_branch_and_push_strategy_prompts_when_default_branch_is_unknown() {
+        assert_eq!(
+            ai_create_branch_and_push_strategy_for_branch("feature/ai-thread", None),
+            AiCreateBranchAndPushStrategy::PromptForPushTarget
         );
     }
 }

--- a/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_git_ops/helpers.rs
@@ -30,52 +30,100 @@ enum AiOpenPrBranchStrategy {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AiCreateBranchAndPushStrategy {
-    CreateBranchImmediately,
-    PromptForPushTarget,
+enum AiBranchDefaultRelation {
+    DefaultBranch,
+    NonDefaultBranch,
+    Unknown,
+}
+
+fn ai_branch_default_relation(
+    repo_root: &std::path::Path,
+    branch_name: &str,
+) -> AiBranchDefaultRelation {
+    let default_branch_name = resolve_default_base_branch_name(repo_root).ok().flatten();
+    ai_branch_default_relation_for_branch(branch_name, default_branch_name.as_deref())
+}
+
+fn ai_branch_default_relation_for_branch(
+    branch_name: &str,
+    default_branch_name: Option<&str>,
+) -> AiBranchDefaultRelation {
+    let branch_name = branch_name.trim();
+    let default_branch_name = default_branch_name.map(str::trim);
+    match default_branch_name {
+        Some(default_branch_name) if default_branch_name == branch_name => {
+            AiBranchDefaultRelation::DefaultBranch
+        }
+        Some(_) => AiBranchDefaultRelation::NonDefaultBranch,
+        None => AiBranchDefaultRelation::Unknown,
+    }
 }
 
 fn ai_open_pr_branch_strategy(
     repo_root: &std::path::Path,
     branch_name: &str,
 ) -> AiOpenPrBranchStrategy {
-    let default_branch_name = resolve_default_base_branch_name(repo_root).ok().flatten();
-    ai_open_pr_branch_strategy_for_branch(branch_name, default_branch_name.as_deref())
+    match ai_branch_default_relation(repo_root, branch_name) {
+        AiBranchDefaultRelation::DefaultBranch => AiOpenPrBranchStrategy::CreateReviewBranch,
+        AiBranchDefaultRelation::NonDefaultBranch | AiBranchDefaultRelation::Unknown => {
+            AiOpenPrBranchStrategy::ReuseCurrentBranch
+        }
+    }
 }
 
+#[cfg(test)]
 fn ai_open_pr_branch_strategy_for_branch(
     branch_name: &str,
     default_branch_name: Option<&str>,
 ) -> AiOpenPrBranchStrategy {
-    let branch_name = branch_name.trim();
-    let default_branch_name = default_branch_name.map(str::trim);
-    if default_branch_name == Some(branch_name) {
-        AiOpenPrBranchStrategy::CreateReviewBranch
-    } else {
-        AiOpenPrBranchStrategy::ReuseCurrentBranch
+    match ai_branch_default_relation_for_branch(branch_name, default_branch_name) {
+        AiBranchDefaultRelation::DefaultBranch => AiOpenPrBranchStrategy::CreateReviewBranch,
+        AiBranchDefaultRelation::NonDefaultBranch | AiBranchDefaultRelation::Unknown => {
+            AiOpenPrBranchStrategy::ReuseCurrentBranch
+        }
     }
 }
 
-fn ai_create_branch_and_push_strategy(
+fn ai_should_prompt_for_create_branch_and_push_target(
     repo_root: &std::path::Path,
     branch_name: &str,
-) -> AiCreateBranchAndPushStrategy {
-    let default_branch_name = resolve_default_base_branch_name(repo_root).ok().flatten();
-    ai_create_branch_and_push_strategy_for_branch(branch_name, default_branch_name.as_deref())
+) -> bool {
+    !matches!(
+        ai_branch_default_relation(repo_root, branch_name),
+        AiBranchDefaultRelation::DefaultBranch
+    )
 }
 
-fn ai_create_branch_and_push_strategy_for_branch(
+#[cfg(test)]
+fn ai_should_prompt_for_create_branch_and_push_target_for_branch(
     branch_name: &str,
     default_branch_name: Option<&str>,
-) -> AiCreateBranchAndPushStrategy {
-    match ai_open_pr_branch_strategy_for_branch(branch_name, default_branch_name) {
-        AiOpenPrBranchStrategy::CreateReviewBranch => {
-            AiCreateBranchAndPushStrategy::CreateBranchImmediately
-        }
-        AiOpenPrBranchStrategy::ReuseCurrentBranch => {
-            AiCreateBranchAndPushStrategy::PromptForPushTarget
-        }
-    }
+) -> bool {
+    !matches!(
+        ai_branch_default_relation_for_branch(branch_name, default_branch_name),
+        AiBranchDefaultRelation::DefaultBranch
+    )
+}
+
+fn ai_should_prompt_for_open_pr_target(
+    repo_root: &std::path::Path,
+    branch_name: &str,
+) -> bool {
+    matches!(
+        ai_branch_default_relation(repo_root, branch_name),
+        AiBranchDefaultRelation::NonDefaultBranch
+    )
+}
+
+#[cfg(test)]
+fn ai_should_prompt_for_open_pr_target_for_branch(
+    branch_name: &str,
+    default_branch_name: Option<&str>,
+) -> bool {
+    matches!(
+        ai_branch_default_relation_for_branch(branch_name, default_branch_name),
+        AiBranchDefaultRelation::NonDefaultBranch
+    )
 }
 
 fn ai_publish_blocker_reason(
@@ -284,26 +332,74 @@ mod ai_git_ops_tests {
     }
 
     #[test]
-    fn create_branch_and_push_strategy_creates_immediately_for_default_branch() {
+    fn branch_default_relation_marks_default_branch() {
         assert_eq!(
-            ai_create_branch_and_push_strategy_for_branch("main", Some("main")),
-            AiCreateBranchAndPushStrategy::CreateBranchImmediately
+            ai_branch_default_relation_for_branch("main", Some("main")),
+            AiBranchDefaultRelation::DefaultBranch
         );
     }
 
     #[test]
-    fn create_branch_and_push_strategy_prompts_for_non_default_branch() {
+    fn branch_default_relation_marks_non_default_branch() {
         assert_eq!(
-            ai_create_branch_and_push_strategy_for_branch("feature/ai-thread", Some("main")),
-            AiCreateBranchAndPushStrategy::PromptForPushTarget
+            ai_branch_default_relation_for_branch("feature/ai-thread", Some("main")),
+            AiBranchDefaultRelation::NonDefaultBranch
         );
     }
 
     #[test]
-    fn create_branch_and_push_strategy_prompts_when_default_branch_is_unknown() {
+    fn branch_default_relation_marks_unknown_when_default_branch_is_missing() {
         assert_eq!(
-            ai_create_branch_and_push_strategy_for_branch("feature/ai-thread", None),
-            AiCreateBranchAndPushStrategy::PromptForPushTarget
+            ai_branch_default_relation_for_branch("feature/ai-thread", None),
+            AiBranchDefaultRelation::Unknown
         );
+    }
+
+    #[test]
+    fn create_branch_and_push_prompts_for_non_default_branch() {
+        assert!(ai_should_prompt_for_create_branch_and_push_target_for_branch(
+            "feature/ai-thread",
+            Some("main"),
+        ));
+    }
+
+    #[test]
+    fn create_branch_and_push_prompts_when_default_branch_is_unknown() {
+        assert!(ai_should_prompt_for_create_branch_and_push_target_for_branch(
+            "feature/ai-thread",
+            None,
+        ));
+    }
+
+    #[test]
+    fn create_branch_and_push_skips_prompt_for_default_branch() {
+        assert!(!ai_should_prompt_for_create_branch_and_push_target_for_branch(
+            "main",
+            Some("main"),
+        ));
+    }
+
+    #[test]
+    fn open_pr_prompts_for_known_non_default_branch() {
+        assert!(ai_should_prompt_for_open_pr_target_for_branch(
+            "feature/ai-thread",
+            Some("main"),
+        ));
+    }
+
+    #[test]
+    fn open_pr_skips_prompt_for_default_branch() {
+        assert!(!ai_should_prompt_for_open_pr_target_for_branch(
+            "main",
+            Some("main"),
+        ));
+    }
+
+    #[test]
+    fn open_pr_skips_prompt_when_default_branch_is_unknown() {
+        assert!(!ai_should_prompt_for_open_pr_target_for_branch(
+            "feature/ai-thread",
+            None,
+        ));
     }
 }

--- a/crates/hunk-desktop/src/app/controller/mod.rs
+++ b/crates/hunk-desktop/src/app/controller/mod.rs
@@ -48,8 +48,8 @@ use hunk_git::history::{
 use hunk_git::mutation::{
     activate_or_create_branch as checkout_or_create_branch_with_change_transfer,
     commit_all_with_details as commit_staged_with_details, commit_index_with_details,
-    restore_working_copy_paths, stage_paths, staged_index_context_for_ai, unstage_paths,
-    working_copy_context_for_ai,
+    create_branch_from_base_with_change_transfer, restore_working_copy_paths, stage_paths,
+    staged_index_context_for_ai, unstage_paths, working_copy_context_for_ai,
 };
 use hunk_git::network::{
     fetch_remote_branches, pull_current_branch_with_rebase as pull_branch_with_rebase,

--- a/crates/hunk-desktop/src/app/controller/mod.rs
+++ b/crates/hunk-desktop/src/app/controller/mod.rs
@@ -1,12 +1,17 @@
 use anyhow::Context as _;
 use futures::StreamExt;
 use futures::channel::{mpsc, oneshot};
+use gpui_component::WindowExt as _;
+use gpui_component::button::{Button, ButtonVariants as _};
+use gpui_component::dialog::{DialogAction, DialogClose, DialogFooter};
 use notify::Watcher;
 use std::cell::RefCell;
 use std::rc::Rc;
 use tracing::{debug, error, warn};
 
-use crate::app::ai_git_progress::ai_delete_worktree_progress_steps;
+use crate::app::ai_git_progress::{
+    ai_create_branch_and_push_progress_steps, ai_delete_worktree_progress_steps,
+};
 use crate::app::ai_thread_flow::{
     AiCodexGenerationConfig, AiCommitGenerationContext, AiCommitMessage,
     ai_branch_generation_seed_for_thread, ai_branch_name_for_prompt, ai_branch_name_for_thread,

--- a/crates/hunk-desktop/src/app/controller/mod.rs
+++ b/crates/hunk-desktop/src/app/controller/mod.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 use futures::channel::{mpsc, oneshot};
 use gpui_component::WindowExt as _;
 use gpui_component::button::{Button, ButtonVariants as _};
-use gpui_component::dialog::{DialogAction, DialogClose, DialogFooter};
+use gpui_component::dialog::DialogFooter;
 use notify::Watcher;
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/crates/hunk-desktop/src/app/render/ai.rs
+++ b/crates/hunk-desktop/src/app/render/ai.rs
@@ -61,6 +61,8 @@ impl DiffViewer {
         let composer_attachment_paths = ai_view_state.composer_attachment_paths.clone();
         let composer_attachment_count = composer_attachment_paths.len();
         let ai_commit_and_push_loading = self.git_action_loading_named("Commit and Push");
+        let ai_create_branch_and_push_loading =
+            self.git_action_loading_named("Create Branch and Push");
         let ai_open_pr_loading = self.git_action_loading_named("Open PR");
         let ai_delete_worktree_loading = self.git_action_loading_named("Delete Worktree");
         let composer_drop_border_color = if ai_view_state.model_supports_image_inputs {
@@ -100,6 +102,7 @@ impl DiffViewer {
             ai_publish_blocker: ai_view_state.ai_publish_blocker.clone(),
             ai_publish_disabled: ai_view_state.ai_publish_disabled,
             ai_commit_and_push_loading,
+            ai_create_branch_and_push_loading,
             ai_open_pr_disabled: ai_view_state.ai_open_pr_disabled,
             ai_open_pr_loading,
             ai_managed_worktree_target: ai_view_state.ai_managed_worktree_target.clone(),

--- a/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
+++ b/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
@@ -26,6 +26,7 @@ struct AiTimelinePanelState {
     ai_publish_blocker: Option<String>,
     ai_publish_disabled: bool,
     ai_commit_and_push_loading: bool,
+    ai_create_branch_and_push_loading: bool,
     ai_open_pr_disabled: bool,
     ai_open_pr_loading: bool,
     ai_managed_worktree_target: Option<WorkspaceTargetSummary>,
@@ -1016,15 +1017,16 @@ impl DiffViewer {
                     .child({
                         let view = view.clone();
                         let push_label = format!("Commit and Push to {}", state.active_branch);
+                        let create_branch_label = "Create Branch and Push".to_string();
                         let publish_tooltip = state.ai_publish_blocker.clone().unwrap_or_else(|| {
                             match state.selected_thread_start_mode {
                                 Some(AiNewThreadStartMode::Local) => {
-                                    "Commit and push this branch directly, or open PR/MR for it. If the current branch is the default branch, Hunk creates a review branch first.".to_string()
+                                    "Commit and push the current branch, create a fresh branch and push it, or open PR/MR for the current work. If the current branch is the default branch, Hunk creates a new branch automatically.".to_string()
                                 }
                                 Some(AiNewThreadStartMode::Worktree) => {
-                                    "Commit and push this worktree branch directly, or open PR/MR for the current branch.".to_string()
+                                    "Commit and push this worktree branch, create a fresh branch and push it, or open PR/MR for the current work.".to_string()
                                 }
-                                None => "Commit and push this branch directly, or open PR/MR for it.".to_string(),
+                                None => "Commit and push this branch, create a fresh branch and push it, or open PR/MR for it.".to_string(),
                             }
                         });
                         Button::new("ai-publish-thread")
@@ -1032,7 +1034,11 @@ impl DiffViewer {
                             .outline()
                             .with_size(gpui_component::Size::Small)
                             .rounded(px(8.0))
-                            .loading(state.ai_commit_and_push_loading || state.ai_open_pr_loading)
+                            .loading(
+                                state.ai_commit_and_push_loading
+                                    || state.ai_create_branch_and_push_loading
+                                    || state.ai_open_pr_loading,
+                            )
                             .dropdown_caret(true)
                             .label("Publish")
                             .tooltip(publish_tooltip)
@@ -1044,6 +1050,18 @@ impl DiffViewer {
                                         move |_, _, cx| {
                                             view.update(cx, |this, cx| {
                                                 this.ai_commit_and_push_for_current_thread(cx);
+                                            });
+                                        }
+                                    }),
+                                )
+                                .item(
+                                    PopupMenuItem::new(create_branch_label.clone()).on_click({
+                                        let view = view.clone();
+                                        move |_, window, cx| {
+                                            view.update(cx, |this, cx| {
+                                                this.ai_create_branch_and_push_for_current_thread(
+                                                    window, cx,
+                                                );
                                             });
                                         }
                                     }),

--- a/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
+++ b/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
@@ -1070,9 +1070,9 @@ impl DiffViewer {
                                 .item(
                                     PopupMenuItem::new("Open PR").on_click({
                                         let view = view.clone();
-                                        move |_, _, cx| {
+                                        move |_, window, cx| {
                                             view.update(cx, |this, cx| {
-                                                this.ai_open_pr_for_current_thread(cx);
+                                                this.ai_open_pr_for_current_thread(window, cx);
                                             });
                                         }
                                     }),

--- a/crates/hunk-desktop/tests/ai_git_progress.rs
+++ b/crates/hunk-desktop/tests/ai_git_progress.rs
@@ -4,7 +4,8 @@ mod ai_git_progress;
 
 use ai_git_progress::{
     AiGitProgressAction, AiGitProgressState, AiGitProgressStep, ai_commit_and_push_progress_steps,
-    ai_delete_worktree_progress_steps, ai_open_pr_progress_steps,
+    ai_create_branch_and_push_progress_steps, ai_delete_worktree_progress_steps,
+    ai_open_pr_progress_steps,
 };
 
 #[test]
@@ -35,6 +36,22 @@ fn open_pr_progress_steps_include_review_branch_generation_when_needed() {
             AiGitProgressStep::PushingBranch,
             AiGitProgressStep::PreparingReviewUrl,
             AiGitProgressStep::OpeningBrowser,
+        ]
+    );
+}
+
+#[test]
+fn create_branch_and_push_progress_steps_include_branch_creation() {
+    let steps = ai_create_branch_and_push_progress_steps();
+
+    assert_eq!(
+        steps,
+        vec![
+            AiGitProgressStep::GeneratingBranchName,
+            AiGitProgressStep::CreatingReviewBranch,
+            AiGitProgressStep::GeneratingCommitMessage,
+            AiGitProgressStep::CreatingCommit,
+            AiGitProgressStep::PushingBranch,
         ]
     );
 }

--- a/crates/hunk-git/src/mutation.rs
+++ b/crates/hunk-git/src/mutation.rs
@@ -8,6 +8,10 @@ use crate::command_env::git_cli_command;
 use crate::git::expand_selected_paths_for_renames;
 use crate::git2_helpers::{load_statuses, open_git2_repo};
 
+mod branch_transfer;
+
+pub use branch_transfer::create_branch_from_base_with_change_transfer;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WorktreeChange {
     AddOrUpdate,
@@ -99,18 +103,11 @@ pub fn activate_or_create_branch(
         branch_name.to_string()
     };
 
-    let target_ref = format!("refs/heads/{target_branch_name}");
-    repo.set_head(target_ref.as_str())
-        .with_context(|| format!("failed to activate branch '{target_branch_name}'"))?;
-
     if repo
         .find_branch(target_branch_name.as_str(), git2::BranchType::Local)
         .is_ok()
     {
-        let mut checkout = git2::build::CheckoutBuilder::new();
-        checkout.force();
-        repo.checkout_head(Some(&mut checkout))
-            .with_context(|| format!("failed to check out branch '{target_branch_name}'"))?;
+        checkout_local_branch(&repo, target_branch_name.as_str())?;
     }
 
     Ok(())
@@ -865,6 +862,18 @@ fn commit_subject(message: &str) -> String {
         .find(|line| !line.trim().is_empty())
         .map(|line| line.trim().to_string())
         .unwrap_or_default()
+}
+
+fn checkout_local_branch(repo: &git2::Repository, branch_name: &str) -> Result<()> {
+    let target_ref = format!("refs/heads/{branch_name}");
+    repo.set_head(target_ref.as_str())
+        .with_context(|| format!("failed to activate branch '{branch_name}'"))?;
+
+    let mut checkout = git2::build::CheckoutBuilder::new();
+    checkout.force();
+    repo.checkout_head(Some(&mut checkout))
+        .with_context(|| format!("failed to check out branch '{branch_name}'"))?;
+    Ok(())
 }
 
 fn current_head_tree(repo: &git2::Repository) -> Result<Option<git2::Tree<'_>>> {

--- a/crates/hunk-git/src/mutation/branch_transfer.rs
+++ b/crates/hunk-git/src/mutation/branch_transfer.rs
@@ -1,0 +1,147 @@
+use std::path::Path;
+
+use anyhow::{Context as _, Result, anyhow};
+use git2::{BranchType, Signature, StashFlags};
+
+use crate::branch::is_valid_branch_name;
+
+pub fn create_branch_from_base_with_change_transfer(
+    repo_root: &Path,
+    branch_name: &str,
+    base_branch_name: &str,
+) -> Result<()> {
+    let branch_name = branch_name.trim();
+    if branch_name.is_empty() {
+        return Err(anyhow!("branch name cannot be empty"));
+    }
+    if !is_valid_branch_name(branch_name) {
+        return Err(anyhow!("invalid branch name: {branch_name}"));
+    }
+
+    let base_branch_name = base_branch_name.trim();
+    if base_branch_name.is_empty() {
+        return Err(anyhow!("base branch name cannot be empty"));
+    }
+    if !is_valid_branch_name(base_branch_name) {
+        return Err(anyhow!("invalid base branch name: {base_branch_name}"));
+    }
+
+    let mut repo = super::open_repo(repo_root)?;
+    super::ensure_no_hidden_index_changes(
+        &repo,
+        "moving changes to a review branch with staged index changes is not supported",
+    )?;
+    if repo.find_branch(branch_name, BranchType::Local).is_ok() {
+        return Err(anyhow!("branch '{branch_name}' already exists"));
+    }
+
+    let original_branch_name = current_local_branch_name(&repo)?.ok_or_else(|| {
+        anyhow!("cannot create branch '{branch_name}' without an active local branch")
+    })?;
+    let changed_paths = super::collect_worktree_changes(&repo, None)?
+        .into_keys()
+        .collect::<Vec<_>>();
+    if changed_paths.is_empty() {
+        return Err(anyhow!(
+            "cannot create isolated branch '{branch_name}' from '{base_branch_name}' without uncommitted changes to transfer"
+        ));
+    }
+
+    let base_commit_id = repo
+        .find_branch(base_branch_name, BranchType::Local)
+        .with_context(|| format!("base branch '{base_branch_name}' does not exist"))?
+        .into_reference()
+        .peel_to_commit()
+        .with_context(|| format!("failed to resolve base branch '{base_branch_name}' commit"))?
+        .id();
+
+    let stash_signature = stash_signature(&repo)?;
+    repo.stash_save(
+        &stash_signature,
+        format!("hunk: transfer changes to {branch_name}").as_str(),
+        Some(StashFlags::INCLUDE_UNTRACKED),
+    )
+    .context("failed to stash working copy changes for branch transfer")?;
+
+    let transfer_result = (|| -> Result<()> {
+        {
+            let base_commit = repo
+                .find_commit(base_commit_id)
+                .with_context(|| format!("failed to reload base commit '{base_commit_id}'"))?;
+            repo.branch(branch_name, &base_commit, false)
+                .with_context(|| {
+                    format!("failed to create branch '{branch_name}' from '{base_branch_name}'")
+                })?;
+        }
+        super::checkout_local_branch(&repo, branch_name)?;
+        repo.stash_pop(0, None).with_context(|| {
+            format!("failed to apply stashed changes onto branch '{branch_name}'")
+        })?;
+        Ok(())
+    })();
+
+    if transfer_result.is_ok() {
+        return Ok(());
+    }
+
+    let transfer_err = transfer_result.expect_err("branch transfer should have failed");
+    rollback_branch_transfer(
+        repo_root,
+        original_branch_name.as_str(),
+        branch_name,
+        changed_paths.as_slice(),
+    )
+    .map_err(|rollback_err| anyhow!("{transfer_err:#}; rollback failed: {rollback_err:#}"))?;
+    Err(transfer_err)
+}
+
+fn current_local_branch_name(repo: &git2::Repository) -> Result<Option<String>> {
+    let head = match repo.head() {
+        Ok(head) => head,
+        Err(err) if err.code() == git2::ErrorCode::UnbornBranch => return Ok(None),
+        Err(err) if err.code() == git2::ErrorCode::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    if !head.is_branch() {
+        return Ok(None);
+    }
+    Ok(head.shorthand().map(ToOwned::to_owned))
+}
+
+fn stash_signature(repo: &git2::Repository) -> Result<Signature<'static>> {
+    repo.signature()
+        .or_else(|_| Signature::now("Hunk", "hunk@example.com"))
+        .context("failed to build stash signature for branch transfer")
+}
+
+fn rollback_branch_transfer(
+    repo_root: &Path,
+    original_branch_name: &str,
+    created_branch_name: &str,
+    changed_paths: &[String],
+) -> Result<()> {
+    super::restore_working_copy_paths(repo_root, changed_paths).with_context(|| {
+        format!(
+            "failed to clean partial branch-transfer changes before restoring '{}'",
+            original_branch_name
+        )
+    })?;
+
+    let repo = super::open_repo(repo_root)?;
+    super::checkout_local_branch(&repo, original_branch_name).with_context(|| {
+        format!("failed to reactivate original branch '{original_branch_name}'")
+    })?;
+
+    let mut repo = super::open_repo(repo_root)?;
+    repo.stash_pop(0, None).with_context(|| {
+        format!("failed to restore stashed changes on branch '{original_branch_name}'")
+    })?;
+
+    if let Ok(mut created_branch) = repo.find_branch(created_branch_name, BranchType::Local) {
+        created_branch.delete().with_context(|| {
+            format!("failed to delete branch '{created_branch_name}' during rollback")
+        })?;
+    }
+
+    Ok(())
+}

--- a/crates/hunk-git/tests/mutation_ops.rs
+++ b/crates/hunk-git/tests/mutation_ops.rs
@@ -170,42 +170,6 @@ fn creating_branch_from_default_requires_uncommitted_changes_to_transfer() -> Re
 }
 
 #[test]
-fn creating_branch_from_default_rolls_back_when_transfer_conflicts() -> Result<()> {
-    let fixture = TempGitRepo::new()?;
-    fixture.write_file("shared.txt", "main\n")?;
-    fixture.commit_all_git2("initial")?;
-    let default_branch = fixture.current_branch_name()?;
-
-    fixture.checkout_branch("feature/existing")?;
-    fixture.write_file("shared.txt", "feature\n")?;
-    fixture.commit_all_git2("feature history")?;
-    fixture.write_file("shared.txt", "feature\npending thread work\n")?;
-
-    let err = create_branch_from_base_with_change_transfer(
-        fixture.root(),
-        "ai/local/thread-review",
-        default_branch.as_str(),
-    )
-    .expect_err("conflicting transfer should restore the original branch state");
-
-    assert!(
-        err.to_string()
-            .contains("failed to apply stashed changes onto branch")
-    );
-    assert_eq!(fixture.current_branch_name()?, "feature/existing");
-    assert_eq!(
-        fs::read_to_string(fixture.root().join("shared.txt"))?,
-        "feature\npending thread work\n"
-    );
-    let repo = fixture.repository()?;
-    assert!(
-        repo.find_branch("ai/local/thread-review", BranchType::Local)
-            .is_err()
-    );
-    Ok(())
-}
-
-#[test]
 fn activating_branch_rejects_hidden_index_changes() -> Result<()> {
     let fixture = TempGitRepo::new()?;
     fixture.write_file("tracked.txt", "base\n")?;

--- a/crates/hunk-git/tests/mutation_ops.rs
+++ b/crates/hunk-git/tests/mutation_ops.rs
@@ -6,8 +6,9 @@ use git2::{BranchType, IndexAddOption, Repository, Signature, build::CheckoutBui
 use hunk_git::git::{FileStatus, load_workflow_snapshot};
 use hunk_git::mutation::{
     activate_or_create_branch, commit_all, commit_all_with_details, commit_index_with_details,
-    commit_selected_paths, commit_selected_paths_with_details, restore_working_copy_paths,
-    stage_paths, staged_index_context_for_ai, unstage_paths, working_copy_context_for_ai,
+    commit_selected_paths, commit_selected_paths_with_details,
+    create_branch_from_base_with_change_transfer, restore_working_copy_paths, stage_paths,
+    staged_index_context_for_ai, unstage_paths, working_copy_context_for_ai,
 };
 use hunk_git::network::{fetch_remote_branches, push_current_branch};
 use tempfile::TempDir;
@@ -90,6 +91,116 @@ fn creating_new_branch_can_keep_dirty_changes_on_review_branch() -> Result<()> {
             .branches
             .iter()
             .any(|branch| branch.name == "ai/local/review-branch" && branch.is_current)
+    );
+    Ok(())
+}
+
+#[test]
+fn creating_branch_from_default_transfers_working_copy_without_feature_history() -> Result<()> {
+    let fixture = TempGitRepo::new()?;
+    fixture.write_file("base.txt", "main\n")?;
+    let default_commit = fixture.commit_all_git2("initial")?;
+    let default_branch = fixture.current_branch_name()?;
+
+    fixture.checkout_branch("feature/existing")?;
+    fixture.write_file("feature-only.txt", "feature history\n")?;
+    let feature_commit = fixture.commit_all_git2("feature history")?;
+    fixture.write_file("ai-thread.txt", "pending thread work\n")?;
+
+    create_branch_from_base_with_change_transfer(
+        fixture.root(),
+        "ai/local/thread-review",
+        default_branch.as_str(),
+    )?;
+
+    let snapshot = load_workflow_snapshot(fixture.root())?;
+    assert_eq!(snapshot.branch_name, "ai/local/thread-review");
+    assert_eq!(
+        fixture.branch_target_oid("ai/local/thread-review")?,
+        default_commit
+    );
+    assert_ne!(
+        fixture.branch_target_oid("ai/local/thread-review")?,
+        feature_commit
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root().join("ai-thread.txt"))?,
+        "pending thread work\n"
+    );
+    assert!(!fixture.root().join("feature-only.txt").exists());
+    assert!(
+        snapshot
+            .files
+            .iter()
+            .any(|file| file.path == "ai-thread.txt" && file.untracked)
+    );
+    Ok(())
+}
+
+#[test]
+fn creating_branch_from_default_requires_uncommitted_changes_to_transfer() -> Result<()> {
+    let fixture = TempGitRepo::new()?;
+    fixture.write_file("base.txt", "main\n")?;
+    fixture.commit_all_git2("initial")?;
+    let default_branch = fixture.current_branch_name()?;
+
+    fixture.checkout_branch("feature/existing")?;
+    fixture.write_file("feature-only.txt", "feature history\n")?;
+    fixture.commit_all_git2("feature history")?;
+
+    let err = create_branch_from_base_with_change_transfer(
+        fixture.root(),
+        "ai/local/thread-review",
+        default_branch.as_str(),
+    )
+    .expect_err("clean feature branch should not create an isolated thread branch");
+
+    assert!(
+        err.to_string()
+            .contains("without uncommitted changes to transfer")
+    );
+    assert_eq!(fixture.current_branch_name()?, "feature/existing");
+    assert!(fixture.root().join("feature-only.txt").exists());
+    let repo = fixture.repository()?;
+    assert!(
+        repo.find_branch("ai/local/thread-review", BranchType::Local)
+            .is_err()
+    );
+    Ok(())
+}
+
+#[test]
+fn creating_branch_from_default_rolls_back_when_transfer_conflicts() -> Result<()> {
+    let fixture = TempGitRepo::new()?;
+    fixture.write_file("shared.txt", "main\n")?;
+    fixture.commit_all_git2("initial")?;
+    let default_branch = fixture.current_branch_name()?;
+
+    fixture.checkout_branch("feature/existing")?;
+    fixture.write_file("shared.txt", "feature\n")?;
+    fixture.commit_all_git2("feature history")?;
+    fixture.write_file("shared.txt", "feature\npending thread work\n")?;
+
+    let err = create_branch_from_base_with_change_transfer(
+        fixture.root(),
+        "ai/local/thread-review",
+        default_branch.as_str(),
+    )
+    .expect_err("conflicting transfer should restore the original branch state");
+
+    assert!(
+        err.to_string()
+            .contains("failed to apply stashed changes onto branch")
+    );
+    assert_eq!(fixture.current_branch_name()?, "feature/existing");
+    assert_eq!(
+        fs::read_to_string(fixture.root().join("shared.txt"))?,
+        "feature\npending thread work\n"
+    );
+    let repo = fixture.repository()?;
+    assert!(
+        repo.find_branch("ai/local/thread-review", BranchType::Local)
+            .is_err()
     );
     Ok(())
 }
@@ -766,6 +877,15 @@ impl TempGitRepo {
         };
         let commit = head.peel_to_commit()?;
         Ok(commit.summary().map(ToOwned::to_owned))
+    }
+
+    fn branch_target_oid(&self, branch_name: &str) -> Result<git2::Oid> {
+        let repo = self.repository()?;
+        Ok(repo
+            .find_branch(branch_name, BranchType::Local)?
+            .into_reference()
+            .target()
+            .expect("local branch should resolve to an oid"))
     }
 
     fn head_commits<'repo>(&self, repo: &'repo Repository) -> Result<Vec<git2::Commit<'repo>>> {


### PR DESCRIPTION
Expose a separate Publish action that creates a fresh branch when needed, with progress tracking and a confirmation dialog when republishing the current branch.