### PR TITLE
Add Chats workspace support to AI composer

### DIFF
--- a/crates/hunk-desktop/src/app/ai_composer_commands.rs
+++ b/crates/hunk-desktop/src/app/ai_composer_commands.rs
@@ -171,9 +171,14 @@ pub(crate) fn slash_command_menu_state(
     text: &str,
     cursor_offset: usize,
     task_in_progress: bool,
+    allow_mode_commands: bool,
 ) -> Option<AiComposerSlashCommandMenuState> {
     let active_token = active_slash_command_token(text, cursor_offset)?;
-    let items = matched_slash_commands(active_token.query.as_str(), task_in_progress);
+    let items = matched_slash_commands(
+        active_token.query.as_str(),
+        task_in_progress,
+        allow_mode_commands,
+    );
     if items.is_empty() {
         return None;
     }
@@ -226,11 +231,21 @@ pub(crate) fn slash_command_disabled_reason(
 fn matched_slash_commands(
     query: &str,
     task_in_progress: bool,
+    allow_mode_commands: bool,
 ) -> Vec<AiComposerSlashCommandMenuItem> {
     let trimmed = query.trim();
     if trimmed.is_empty() {
         return slash_command_items()
             .iter()
+            .filter(|item| {
+                allow_mode_commands
+                    || !matches!(
+                        item.kind,
+                        AiComposerSlashCommandKind::Code
+                            | AiComposerSlashCommandKind::Plan
+                            | AiComposerSlashCommandKind::Review
+                    )
+            })
             .copied()
             .map(|item| AiComposerSlashCommandMenuItem {
                 disabled_reason: slash_command_disabled_reason(item, task_in_progress),
@@ -242,6 +257,15 @@ fn matched_slash_commands(
     let normalized_query = trimmed.to_ascii_lowercase();
     let mut ranked = slash_command_items()
         .iter()
+        .filter(|item| {
+            allow_mode_commands
+                || !matches!(
+                    item.kind,
+                    AiComposerSlashCommandKind::Code
+                        | AiComposerSlashCommandKind::Plan
+                        | AiComposerSlashCommandKind::Review
+                )
+        })
         .filter_map(|item| {
             let label_key = item.label.to_ascii_lowercase();
             let name_key = item.name.to_ascii_lowercase();
@@ -326,13 +350,15 @@ mod tests {
 
     #[test]
     fn slash_command_menu_matches_on_name_and_description() {
-        let menu = slash_command_menu_state("/st", 3, false).expect("menu should exist");
+        let menu = slash_command_menu_state("/st", 3, false, true).expect("menu should exist");
         assert_eq!(menu.items[0].item.kind, AiComposerSlashCommandKind::Usage);
 
-        let menu = slash_command_menu_state("/disconnect", 11, false).expect("menu should exist");
+        let menu =
+            slash_command_menu_state("/disconnect", 11, false, true).expect("menu should exist");
         assert_eq!(menu.items[0].item.kind, AiComposerSlashCommandKind::Logout);
 
-        let menu = slash_command_menu_state("/fast-mode-o", 12, false).expect("menu should exist");
+        let menu =
+            slash_command_menu_state("/fast-mode-o", 12, false, true).expect("menu should exist");
         assert_eq!(
             menu.items[0].item.kind,
             AiComposerSlashCommandKind::FastModeOn
@@ -342,7 +368,7 @@ mod tests {
     #[test]
     fn slash_command_menu_keeps_fast_mode_toggle_variants_distinct() {
         let menu =
-            slash_command_menu_state("/fast-mode-off", 14, false).expect("menu should exist");
+            slash_command_menu_state("/fast-mode-off", 14, false, true).expect("menu should exist");
         assert_eq!(
             menu.items[0].item.kind,
             AiComposerSlashCommandKind::FastModeOff
@@ -351,7 +377,7 @@ mod tests {
 
     #[test]
     fn slash_command_menu_marks_idle_only_commands_disabled_during_active_turns() {
-        let menu = slash_command_menu_state("/fast", 5, true).expect("menu should exist");
+        let menu = slash_command_menu_state("/fast", 5, true, true).expect("menu should exist");
         assert_eq!(
             menu.items[0].disabled_reason,
             Some("Disabled while a task is in progress.")
@@ -363,6 +389,19 @@ mod tests {
             .copied()
             .expect("usage command should exist");
         assert_eq!(slash_command_disabled_reason(usage_item, true), None);
+    }
+
+    #[test]
+    fn plain_chat_filters_mode_switch_slash_commands() {
+        let menu = slash_command_menu_state("/", 1, false, false).expect("menu should exist");
+        assert!(menu.items.iter().all(|item| {
+            !matches!(
+                item.item.kind,
+                AiComposerSlashCommandKind::Code
+                    | AiComposerSlashCommandKind::Plan
+                    | AiComposerSlashCommandKind::Review
+            )
+        }));
     }
 
     #[test]

--- a/crates/hunk-desktop/src/app/ai_paths.rs
+++ b/crates/hunk-desktop/src/app/ai_paths.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(super) fn resolve_codex_home_path() -> Option<PathBuf> {
     resolve_codex_home_path_from(
@@ -24,6 +26,55 @@ pub(super) fn ensure_ai_chats_root_path() -> Option<PathBuf> {
     let chats_root = resolve_ai_chats_root_path()?;
     fs::create_dir_all(&chats_root).ok()?;
     Some(chats_root)
+}
+
+pub(super) fn is_ai_chats_workspace_path(path: &Path) -> bool {
+    resolve_ai_chats_root_path()
+        .is_some_and(|chats_root| path == chats_root || path.starts_with(chats_root))
+}
+
+pub(super) fn ai_chats_workspace_paths() -> Vec<PathBuf> {
+    let Some(chats_root) = ensure_ai_chats_root_path().or_else(resolve_ai_chats_root_path) else {
+        return Vec::new();
+    };
+
+    let mut workspaces = vec![chats_root.clone()];
+    let Ok(entries) = fs::read_dir(&chats_root) else {
+        return workspaces;
+    };
+
+    let mut children = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    children.sort();
+    workspaces.extend(children);
+    workspaces
+}
+
+pub(super) fn allocate_ai_chat_thread_workspace_path() -> Option<PathBuf> {
+    static NEXT_CHAT_WORKSPACE_ID: AtomicU64 = AtomicU64::new(0);
+
+    let chats_root = ensure_ai_chats_root_path().or_else(resolve_ai_chats_root_path)?;
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let process_id = std::process::id();
+
+    for _ in 0..128 {
+        let suffix = NEXT_CHAT_WORKSPACE_ID.fetch_add(1, Ordering::Relaxed);
+        let candidate = chats_root.join(format!("chat-{seed:x}-{process_id:x}-{suffix:x}"));
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Some(candidate),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return None,
+        }
+    }
+
+    None
 }
 
 fn user_home_dir() -> Option<PathBuf> {
@@ -70,7 +121,10 @@ fn home_relative_suffix(path: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use super::ai_chats_workspace_paths;
+    use super::allocate_ai_chat_thread_workspace_path;
     use super::expand_home_prefixed_path;
+    use super::is_ai_chats_workspace_path;
     use super::resolve_ai_chats_root_path;
     use super::resolve_codex_home_path_from;
     use std::path::PathBuf;
@@ -149,5 +203,80 @@ mod tests {
             resolved,
             Some(PathBuf::from("/tmp").join("custom-hunk-home").join("chats")),
         );
+    }
+
+    #[test]
+    fn chats_workspace_classifies_descendants() {
+        let _guard = env_lock().lock().expect("env lock should be available");
+        let hunk_home = std::env::temp_dir().join("hunk-ai-paths-descendants");
+        let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
+        unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &hunk_home) };
+
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+        let thread_root = chats_root.join("chat-1");
+
+        assert!(is_ai_chats_workspace_path(chats_root.as_path()));
+        assert!(is_ai_chats_workspace_path(thread_root.as_path()));
+        assert!(!is_ai_chats_workspace_path(PathBuf::from("/repo").as_path()));
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, value)
+            },
+            None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
+        }
+    }
+
+    #[test]
+    fn chat_workspace_paths_include_root_and_children() {
+        let _guard = env_lock().lock().expect("env lock should be available");
+        let hunk_home = std::env::temp_dir().join("hunk-ai-paths-workspaces");
+        let chats_root = hunk_home.join("chats");
+        let child_a = chats_root.join("chat-a");
+        let child_b = chats_root.join("chat-b");
+        let hidden_file = chats_root.join(".note");
+        let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
+        unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &hunk_home) };
+        let _ = std::fs::remove_dir_all(&hunk_home);
+        std::fs::create_dir_all(&child_a).expect("chat-a should exist");
+        std::fs::create_dir_all(&child_b).expect("chat-b should exist");
+        std::fs::write(&hidden_file, "ignore").expect("hidden file should exist");
+
+        let workspaces = ai_chats_workspace_paths();
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, value)
+            },
+            None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
+        }
+        let _ = std::fs::remove_dir_all(&hunk_home);
+
+        assert_eq!(workspaces, vec![chats_root, child_a, child_b]);
+    }
+
+    #[test]
+    fn allocate_chat_thread_workspace_creates_unique_child_directory() {
+        let _guard = env_lock().lock().expect("env lock should be available");
+        let hunk_home = std::env::temp_dir().join("hunk-ai-paths-allocate");
+        let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
+        unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &hunk_home) };
+        let _ = std::fs::remove_dir_all(&hunk_home);
+
+        let first = allocate_ai_chat_thread_workspace_path().expect("first workspace should exist");
+        let second =
+            allocate_ai_chat_thread_workspace_path().expect("second workspace should exist");
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, value)
+            },
+            None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
+        }
+        let _ = std::fs::remove_dir_all(&hunk_home);
+
+        assert_ne!(first, second);
+        assert!(first.parent().is_some_and(|parent| parent.ends_with("chats")));
+        assert!(second.parent().is_some_and(|parent| parent.ends_with("chats")));
     }
 }

--- a/crates/hunk-desktop/src/app/ai_paths.rs
+++ b/crates/hunk-desktop/src/app/ai_paths.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::ffi::OsStr;
+use std::fs;
 use std::path::{Component, Path, PathBuf};
 
 pub(super) fn resolve_codex_home_path() -> Option<PathBuf> {
@@ -11,6 +12,18 @@ pub(super) fn resolve_codex_home_path() -> Option<PathBuf> {
 
 pub(super) fn default_codex_home_path() -> Option<PathBuf> {
     user_home_dir().map(|home_dir| home_dir.join(".codex"))
+}
+
+pub(super) fn resolve_ai_chats_root_path() -> Option<PathBuf> {
+    hunk_domain::paths::hunk_home_dir()
+        .ok()
+        .map(|home_dir| home_dir.join("chats"))
+}
+
+pub(super) fn ensure_ai_chats_root_path() -> Option<PathBuf> {
+    let chats_root = resolve_ai_chats_root_path()?;
+    fs::create_dir_all(&chats_root).ok()?;
+    Some(chats_root)
 }
 
 fn user_home_dir() -> Option<PathBuf> {
@@ -58,8 +71,15 @@ fn home_relative_suffix(path: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::expand_home_prefixed_path;
+    use super::resolve_ai_chats_root_path;
     use super::resolve_codex_home_path_from;
     use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn default_codex_home_uses_resolved_home_directory() {
@@ -103,5 +123,31 @@ mod tests {
         let resolved = expand_home_prefixed_path(PathBuf::from("~"), Some(home_dir.as_path()));
 
         assert_eq!(resolved, Some(home_dir));
+    }
+
+    #[test]
+    fn chats_root_uses_hunk_home_dir_override() {
+        let _guard = env_lock().lock().expect("env lock should be available");
+        let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
+        unsafe {
+            std::env::set_var(
+                hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR,
+                PathBuf::from("/tmp").join("custom-hunk-home"),
+            );
+        }
+
+        let resolved = resolve_ai_chats_root_path();
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, value)
+            },
+            None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
+        }
+
+        assert_eq!(
+            resolved,
+            Some(PathBuf::from("/tmp").join("custom-hunk-home").join("chats")),
+        );
     }
 }

--- a/crates/hunk-desktop/src/app/ai_paths.rs
+++ b/crates/hunk-desktop/src/app/ai_paths.rs
@@ -217,7 +217,9 @@ mod tests {
 
         assert!(is_ai_chats_workspace_path(chats_root.as_path()));
         assert!(is_ai_chats_workspace_path(thread_root.as_path()));
-        assert!(!is_ai_chats_workspace_path(PathBuf::from("/repo").as_path()));
+        assert!(!is_ai_chats_workspace_path(
+            PathBuf::from("/repo").as_path()
+        ));
 
         match previous {
             Some(value) => unsafe {
@@ -276,7 +278,15 @@ mod tests {
         let _ = std::fs::remove_dir_all(&hunk_home);
 
         assert_ne!(first, second);
-        assert!(first.parent().is_some_and(|parent| parent.ends_with("chats")));
-        assert!(second.parent().is_some_and(|parent| parent.ends_with("chats")));
+        assert!(
+            first
+                .parent()
+                .is_some_and(|parent| parent.ends_with("chats"))
+        );
+        assert!(
+            second
+                .parent()
+                .is_some_and(|parent| parent.ends_with("chats"))
+        );
     }
 }

--- a/crates/hunk-desktop/src/app/ai_paths.rs
+++ b/crates/hunk-desktop/src/app/ai_paths.rs
@@ -3,9 +3,9 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(super) fn resolve_codex_home_path() -> Option<PathBuf> {
     resolve_codex_home_path_from(
@@ -213,10 +213,7 @@ mod tests {
         }
         let _ = std::fs::remove_dir_all(&hunk_home);
 
-        assert_eq!(
-            resolved,
-            Some(expected),
-        );
+        assert_eq!(resolved, Some(expected),);
     }
 
     #[test]

--- a/crates/hunk-desktop/src/app/ai_paths.rs
+++ b/crates/hunk-desktop/src/app/ai_paths.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 pub(super) fn resolve_codex_home_path() -> Option<PathBuf> {
     resolve_codex_home_path_from(
@@ -77,6 +79,15 @@ pub(super) fn allocate_ai_chat_thread_workspace_path() -> Option<PathBuf> {
     None
 }
 
+#[cfg(test)]
+pub(crate) fn lock_hunk_home_test_env() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(error) => error.into_inner(),
+    }
+}
+
 fn user_home_dir() -> Option<PathBuf> {
     dirs::home_dir()
         .or_else(|| env::var_os("HOME").map(PathBuf::from))
@@ -125,14 +136,17 @@ mod tests {
     use super::allocate_ai_chat_thread_workspace_path;
     use super::expand_home_prefixed_path;
     use super::is_ai_chats_workspace_path;
+    use super::lock_hunk_home_test_env;
     use super::resolve_ai_chats_root_path;
     use super::resolve_codex_home_path_from;
     use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
 
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+    fn canonicalize_if_exists(path: PathBuf) -> PathBuf {
+        if !path.exists() {
+            return path;
+        }
+
+        std::fs::canonicalize(path.as_path()).unwrap_or(path)
     }
 
     #[test]
@@ -181,16 +195,15 @@ mod tests {
 
     #[test]
     fn chats_root_uses_hunk_home_dir_override() {
-        let _guard = env_lock().lock().expect("env lock should be available");
+        let _guard = lock_hunk_home_test_env();
+        let hunk_home = std::env::temp_dir().join("custom-hunk-home");
         let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
-        unsafe {
-            std::env::set_var(
-                hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR,
-                PathBuf::from("/tmp").join("custom-hunk-home"),
-            );
-        }
+        let _ = std::fs::remove_dir_all(&hunk_home);
+        std::fs::create_dir_all(&hunk_home).expect("override hunk home should exist");
+        unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &hunk_home) };
 
         let resolved = resolve_ai_chats_root_path();
+        let expected = canonicalize_if_exists(hunk_home.clone()).join("chats");
 
         match previous {
             Some(value) => unsafe {
@@ -198,18 +211,21 @@ mod tests {
             },
             None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
         }
+        let _ = std::fs::remove_dir_all(&hunk_home);
 
         assert_eq!(
             resolved,
-            Some(PathBuf::from("/tmp").join("custom-hunk-home").join("chats")),
+            Some(expected),
         );
     }
 
     #[test]
     fn chats_workspace_classifies_descendants() {
-        let _guard = env_lock().lock().expect("env lock should be available");
+        let _guard = lock_hunk_home_test_env();
         let hunk_home = std::env::temp_dir().join("hunk-ai-paths-descendants");
         let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
+        let _ = std::fs::remove_dir_all(&hunk_home);
+        std::fs::create_dir_all(&hunk_home).expect("override hunk home should exist");
         unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &hunk_home) };
 
         let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
@@ -227,11 +243,12 @@ mod tests {
             },
             None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
         }
+        let _ = std::fs::remove_dir_all(&hunk_home);
     }
 
     #[test]
     fn chat_workspace_paths_include_root_and_children() {
-        let _guard = env_lock().lock().expect("env lock should be available");
+        let _guard = lock_hunk_home_test_env();
         let hunk_home = std::env::temp_dir().join("hunk-ai-paths-workspaces");
         let chats_root = hunk_home.join("chats");
         let child_a = chats_root.join("chat-a");
@@ -245,6 +262,11 @@ mod tests {
         std::fs::write(&hidden_file, "ignore").expect("hidden file should exist");
 
         let workspaces = ai_chats_workspace_paths();
+        let expected = vec![
+            canonicalize_if_exists(chats_root.clone()),
+            canonicalize_if_exists(child_a.clone()),
+            canonicalize_if_exists(child_b.clone()),
+        ];
 
         match previous {
             Some(value) => unsafe {
@@ -254,12 +276,12 @@ mod tests {
         }
         let _ = std::fs::remove_dir_all(&hunk_home);
 
-        assert_eq!(workspaces, vec![chats_root, child_a, child_b]);
+        assert_eq!(workspaces, expected);
     }
 
     #[test]
     fn allocate_chat_thread_workspace_creates_unique_child_directory() {
-        let _guard = env_lock().lock().expect("env lock should be available");
+        let _guard = lock_hunk_home_test_env();
         let hunk_home = std::env::temp_dir().join("hunk-ai-paths-allocate");
         let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
         unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &hunk_home) };

--- a/crates/hunk-desktop/src/app/ai_runtime/core.rs
+++ b/crates/hunk-desktop/src/app/ai_runtime/core.rs
@@ -78,6 +78,7 @@ const NOTIFICATION_DRAIN_TIMEOUT: Duration = Duration::from_millis(2);
 const MAX_NOTIFICATIONS_PER_POLL: usize = 256;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const HOST_BOOTSTRAP_MAX_ATTEMPTS: usize = 12;
+const AI_CHATS_DEVELOPER_INSTRUCTIONS: &str = "This working directory is isolated scratch space for the current Chats thread only. Do not inspect sibling chat directories or treat files here as shared durable context unless the user explicitly asks you to.";
 const TRANSIENT_ROLLOUT_LOAD_MAX_RETRIES: usize = 3;
 const TRANSIENT_ROLLOUT_LOAD_RETRY_DELAY: Duration = Duration::from_millis(75);
 const LOOPBACK_PORT_RANGE_START: u16 = 49_152;
@@ -1008,13 +1009,19 @@ impl AiWorkerRuntime {
             settings: Settings {
                 model,
                 reasoning_effort: effort,
-                developer_instructions: None,
+                developer_instructions: self
+                    .is_chats_workspace()
+                    .then(|| AI_CHATS_DEVELOPER_INSTRUCTIONS.to_string()),
             },
         };
         params.collaboration_mode = Some(collaboration_mode);
         // Collaboration mode takes precedence over model/effort in the server.
         params.model = None;
         params.effort = None;
+    }
+
+    fn is_chats_workspace(&self) -> bool {
+        crate::app::ai_paths::is_ai_chats_workspace_path(self.service.cwd())
     }
 
     fn default_model_id(&self) -> Option<String> {

--- a/crates/hunk-desktop/src/app/controller/ai/catalog.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/catalog.rs
@@ -279,8 +279,8 @@ fn ai_known_workspace_keys(
         .iter()
         .map(|target| target.root.to_string_lossy().to_string())
         .collect::<std::collections::BTreeSet<_>>();
-    if let Some(chats_root) = crate::app::ai_paths::resolve_ai_chats_root_path() {
-        workspace_keys.insert(chats_root.to_string_lossy().to_string());
+    for chats_workspace in crate::app::ai_paths::ai_chats_workspace_paths() {
+        workspace_keys.insert(chats_workspace.to_string_lossy().to_string());
     }
     workspace_keys
 }
@@ -364,9 +364,7 @@ fn ai_workspace_catalog_inputs_from_target_sets(
         );
     }
 
-    if let Some(chats_root) = crate::app::ai_paths::ensure_ai_chats_root_path()
-        .or_else(crate::app::ai_paths::resolve_ai_chats_root_path)
-    {
+    for chats_root in crate::app::ai_paths::ai_chats_workspace_paths() {
         register_ai_workspace_root_for_catalog(
             &mut inputs,
             chats_root.as_path(),

--- a/crates/hunk-desktop/src/app/controller/ai/catalog.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/catalog.rs
@@ -275,10 +275,14 @@ struct AiWorkspaceThreadCatalogLoadResult {
 fn ai_known_workspace_keys(
     workspace_targets: &[hunk_git::worktree::WorkspaceTargetSummary],
 ) -> std::collections::BTreeSet<String> {
-    workspace_targets
+    let mut workspace_keys = workspace_targets
         .iter()
         .map(|target| target.root.to_string_lossy().to_string())
-        .collect()
+        .collect::<std::collections::BTreeSet<_>>();
+    if let Some(chats_root) = crate::app::ai_paths::resolve_ai_chats_root_path() {
+        workspace_keys.insert(chats_root.to_string_lossy().to_string());
+    }
+    workspace_keys
 }
 
 #[cfg(test)]
@@ -356,6 +360,16 @@ fn ai_workspace_catalog_inputs_from_target_sets(
         register_ai_workspace_root_for_catalog(
             &mut inputs,
             project_root.as_path(),
+            visible_workspace_key,
+        );
+    }
+
+    if let Some(chats_root) = crate::app::ai_paths::ensure_ai_chats_root_path()
+        .or_else(crate::app::ai_paths::resolve_ai_chats_root_path)
+    {
+        register_ai_workspace_root_for_catalog(
+            &mut inputs,
+            chats_root.as_path(),
             visible_workspace_key,
         );
     }

--- a/crates/hunk-desktop/src/app/controller/ai/core_actions.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/core_actions.rs
@@ -173,6 +173,14 @@ impl DiffViewer {
         if self.workspace_view_mode != WorkspaceViewMode::Ai {
             return;
         }
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            self.set_current_ai_composer_status(
+                "Worktree threads are unavailable in Chats.",
+                cx,
+            );
+            cx.notify();
+            return;
+        }
         self.ai_start_thread_draft(AiNewThreadStartMode::Worktree, window, cx);
     }
 
@@ -183,6 +191,14 @@ impl DiffViewer {
         cx: &mut Context<Self>,
     ) {
         if self.workspace_view_mode != WorkspaceViewMode::Ai {
+            return;
+        }
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            self.set_current_ai_composer_status(
+                "Diff review is unavailable in Chats.",
+                cx,
+            );
+            cx.notify();
             return;
         }
         self.ai_toggle_inline_review_for_current_thread_in_mode(
@@ -196,6 +212,9 @@ impl DiffViewer {
         start_mode: AiNewThreadStartMode,
         cx: &mut Context<Self>,
     ) {
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            return;
+        }
         if !self.ai_new_thread_draft_active || self.ai_pending_new_thread_selection {
             return;
         }
@@ -219,6 +238,10 @@ impl DiffViewer {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            self.ai_start_chat_thread_draft(window, cx);
+            return;
+        }
         let Some(project_root) = self
             .ai_visible_project_root()
             .or_else(|| self.primary_repo_root())
@@ -277,6 +300,29 @@ impl DiffViewer {
         } else {
             self.ai_worktree_base_branch_name = None;
         }
+        self.sync_ai_worktree_base_branch_picker_state(cx);
+        self.sync_ai_workspace_target_from_catalog(cx);
+        self.ai_create_thread_action(window, cx);
+    }
+
+    pub(super) fn ai_start_chat_thread_draft(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(chats_root) = self.ai_chats_root_path() else {
+            self.set_current_ai_composer_status(
+                "Failed to resolve the Chats workspace.",
+                cx,
+            );
+            cx.notify();
+            return;
+        };
+
+        self.ai_new_thread_start_mode = AiNewThreadStartMode::Local;
+        self.ai_draft_workspace_root_override = Some(chats_root);
+        self.ai_draft_workspace_target_id = None;
+        self.ai_worktree_base_branch_name = None;
         self.sync_ai_worktree_base_branch_picker_state(cx);
         self.sync_ai_workspace_target_from_catalog(cx);
         self.ai_create_thread_action(window, cx);
@@ -581,6 +627,14 @@ impl DiffViewer {
     }
 
     fn start_current_ai_review(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            self.set_current_ai_composer_status(
+                "Review mode is unavailable in Chats.",
+                cx,
+            );
+            cx.notify();
+            return false;
+        }
         if let Some(reason) = self.ai_review_blocker() {
             self.set_current_ai_composer_status(reason, cx);
             cx.notify();
@@ -740,6 +794,18 @@ impl DiffViewer {
         selection: AiCollaborationModeSelection,
         cx: &mut Context<Self>,
     ) {
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            self.ai_selected_collaboration_mode = AiCollaborationModeSelection::Default;
+            self.ai_review_mode_active = false;
+            self.persist_current_ai_workspace_session();
+            self.set_current_ai_composer_status(
+                "Mode switching is unavailable in Chats.",
+                cx,
+            );
+            self.invalidate_ai_visible_frame_state_with_reason("settings");
+            cx.notify();
+            return;
+        }
         let current_thread_id = self.current_ai_thread_id();
         if let Some(thread_id) = current_thread_id.as_ref() {
             self.ai_review_mode_thread_ids.remove(thread_id.as_str());
@@ -762,6 +828,14 @@ impl DiffViewer {
     }
 
     pub(super) fn ai_select_review_mode_action(&mut self, cx: &mut Context<Self>) {
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            self.set_current_ai_composer_status(
+                "Review mode is unavailable in Chats.",
+                cx,
+            );
+            cx.notify();
+            return;
+        }
         let Some(thread_id) = self.current_ai_thread_id() else {
             self.set_current_ai_composer_status(
                 "Select a thread before switching to review mode.",

--- a/crates/hunk-desktop/src/app/controller/ai/core_timeline.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/core_timeline.rs
@@ -210,6 +210,10 @@ impl DiffViewer {
 
         let build_started_at = Instant::now();
         let resolved = self.resolve_ai_current_state();
+        let workspace_kind = resolved_ai_workspace_kind_for_root(
+            resolved.workspace_root.as_deref(),
+            self.ai_chats_root_path().as_deref(),
+        );
         let (project_count, visible_thread_count, threads_loading) = {
             let project_count = self.ai_visible_thread_sections().len();
             let visible_thread_count = self
@@ -246,9 +250,8 @@ impl DiffViewer {
                 resolved.current_thread_id.as_deref(),
                 resolved.workspace_key.as_deref(),
             );
-            let selected_thread_start_mode = selected_thread_id
-                .as_deref()
-                .and_then(|_| {
+            let selected_thread_start_mode = if workspace_kind.shows_repo_actions() {
+                selected_thread_id.as_deref().and_then(|_| {
                     resolved
                         .current_thread_workspace_root
                         .as_deref()
@@ -260,9 +263,13 @@ impl DiffViewer {
                             )
                         })
                 })
-                .flatten();
+                .flatten()
+            } else {
+                None
+            };
             let selected_workspace_root = resolved.workspace_root.clone();
-            let show_worktree_base_branch_picker = self.ai_show_worktree_base_branch_picker();
+            let show_worktree_base_branch_picker =
+                workspace_kind.shows_repo_actions() && self.ai_show_worktree_base_branch_picker();
             let selected_worktree_base_branch = self
                 .ai_selected_worktree_base_branch_name()
                 .unwrap_or("Choose base branch")
@@ -293,10 +300,14 @@ impl DiffViewer {
         } else {
             (0, 0, 0, Vec::new())
         };
-        let inline_review_selected_row_id = selected_thread_id
-            .as_deref()
-            .and_then(|thread_id| self.current_ai_inline_review_row_id_for_thread(thread_id))
-            .map(str::to_string);
+        let inline_review_selected_row_id = if workspace_kind.shows_repo_actions() {
+            selected_thread_id
+                .as_deref()
+                .and_then(|thread_id| self.current_ai_inline_review_row_id_for_thread(thread_id))
+                .map(str::to_string)
+        } else {
+            None
+        };
         self.sync_ai_workspace_session_for_timeline(
             selected_thread_id.as_deref(),
             timeline_visible_row_ids.as_slice(),
@@ -368,90 +379,112 @@ impl DiffViewer {
             ai_delete_worktree_blocker,
             terminal_cwd_label,
         ) = {
-            let review_action_blocker = match selected_thread_id.as_deref() {
-                Some(_) if selected_thread_in_progress => {
-                    Some("Wait for the current run to finish or interrupt it first.".to_string())
-                }
-                Some(_) => None,
-                None => Some("Select a thread before starting review.".to_string()),
-            };
-            let ai_publish_blocker = match (
-                self.git_controls_busy(),
-                selected_thread_id.as_deref(),
-                selected_thread_start_mode,
-                selected_workspace_root.as_deref(),
-            ) {
-                (true, _, _, _) => Some("Another workspace action is in progress.".to_string()),
-                (_, None, _, _) => Some("Select a thread before publishing.".to_string()),
-                (_, Some(_), None, _) => {
-                    Some("Unable to resolve the selected thread before publishing.".to_string())
-                }
-                (_, Some(_), Some(_), None) => {
-                    Some("Open a workspace before publishing.".to_string())
-                }
-                (_, Some(thread_id), Some(start_mode), Some(repo_root)) => {
-                    let normalized_branch = active_branch.trim();
-                    if normalized_branch.is_empty()
-                        || matches!(normalized_branch, "detached" | "unknown")
-                    {
-                        Some("Activate a branch before publishing.".to_string())
-                    } else {
-                        let _context = AiThreadGitActionContext {
-                            repo_root: repo_root.to_path_buf(),
-                            thread_id: thread_id.to_string(),
-                            branch_name: normalized_branch.to_string(),
-                            start_mode,
-                        };
-                        None
+            let review_action_blocker = if workspace_kind.shows_repo_actions() {
+                match selected_thread_id.as_deref() {
+                    Some(_) if selected_thread_in_progress => {
+                        Some("Wait for the current run to finish or interrupt it first.".to_string())
                     }
+                    Some(_) => None,
+                    None => Some("Select a thread before starting review.".to_string()),
                 }
-            };
-            let ai_publish_disabled = ai_publish_blocker.is_some();
-            let ai_open_pr_disabled = match (
-                self.git_controls_busy(),
-                selected_thread_id.as_deref(),
-                selected_thread_start_mode,
-                selected_workspace_root.as_deref(),
-            ) {
-                (true, _, _, _) => true,
-                (_, Some(_), Some(_), Some(_)) => {
-                    let normalized_branch = active_branch.trim();
-                    normalized_branch.is_empty()
-                        || matches!(normalized_branch, "detached" | "unknown")
-                }
-                _ => true,
-            };
-            let ai_managed_worktree_target = if selected_thread_start_mode
-                == Some(AiNewThreadStartMode::Worktree)
-            {
-                selected_workspace_root
-                    .as_deref()
-                    .and_then(|workspace_root| {
-                        workspace_target_summary_for_root(
-                            workspace_root,
-                            &self.workspace_targets,
-                            self.workspace_project_states
-                                .values()
-                                .map(|state| state.workspace_targets.as_slice()),
-                        )
-                        .filter(|target| {
-                            target.kind == hunk_git::worktree::WorkspaceTargetKind::LinkedWorktree
-                                && target.managed
-                        })
-                        .cloned()
-                    })
             } else {
-                None
+                Some("Review mode is unavailable in Chats.".to_string())
             };
-            let ai_delete_worktree_blocker = ai_managed_worktree_target.as_ref().and_then(|_| {
-                if self.git_controls_busy() {
-                    Some("Another workspace action is in progress.".to_string())
-                } else if selected_thread_in_progress {
-                    Some("Wait for the current run to finish or interrupt it first.".to_string())
+            let (
+                ai_publish_blocker,
+                ai_publish_disabled,
+                ai_open_pr_disabled,
+                ai_managed_worktree_target,
+                ai_delete_worktree_blocker,
+            ) = if workspace_kind.shows_repo_actions() {
+                let ai_publish_blocker = match (
+                    self.git_controls_busy(),
+                    selected_thread_id.as_deref(),
+                    selected_thread_start_mode,
+                    selected_workspace_root.as_deref(),
+                ) {
+                    (true, _, _, _) => Some("Another workspace action is in progress.".to_string()),
+                    (_, None, _, _) => Some("Select a thread before publishing.".to_string()),
+                    (_, Some(_), None, _) => {
+                        Some("Unable to resolve the selected thread before publishing.".to_string())
+                    }
+                    (_, Some(_), Some(_), None) => {
+                        Some("Open a workspace before publishing.".to_string())
+                    }
+                    (_, Some(thread_id), Some(start_mode), Some(repo_root)) => {
+                        let normalized_branch = active_branch.trim();
+                        if normalized_branch.is_empty()
+                            || matches!(normalized_branch, "detached" | "unknown")
+                        {
+                            Some("Activate a branch before publishing.".to_string())
+                        } else {
+                            let _context = AiThreadGitActionContext {
+                                repo_root: repo_root.to_path_buf(),
+                                thread_id: thread_id.to_string(),
+                                branch_name: normalized_branch.to_string(),
+                                start_mode,
+                            };
+                            None
+                        }
+                    }
+                };
+                let ai_publish_disabled = ai_publish_blocker.is_some();
+                let ai_open_pr_disabled = match (
+                    self.git_controls_busy(),
+                    selected_thread_id.as_deref(),
+                    selected_thread_start_mode,
+                    selected_workspace_root.as_deref(),
+                ) {
+                    (true, _, _, _) => true,
+                    (_, Some(_), Some(_), Some(_)) => {
+                        let normalized_branch = active_branch.trim();
+                        normalized_branch.is_empty()
+                            || matches!(normalized_branch, "detached" | "unknown")
+                    }
+                    _ => true,
+                };
+                let ai_managed_worktree_target = if selected_thread_start_mode
+                    == Some(AiNewThreadStartMode::Worktree)
+                {
+                    selected_workspace_root
+                        .as_deref()
+                        .and_then(|workspace_root| {
+                            workspace_target_summary_for_root(
+                                workspace_root,
+                                &self.workspace_targets,
+                                self.workspace_project_states
+                                    .values()
+                                    .map(|state| state.workspace_targets.as_slice()),
+                            )
+                            .filter(|target| {
+                                target.kind == hunk_git::worktree::WorkspaceTargetKind::LinkedWorktree
+                                    && target.managed
+                            })
+                            .cloned()
+                        })
                 } else {
                     None
-                }
-            });
+                };
+                let ai_delete_worktree_blocker =
+                    ai_managed_worktree_target.as_ref().and_then(|_| {
+                        if self.git_controls_busy() {
+                            Some("Another workspace action is in progress.".to_string())
+                        } else if selected_thread_in_progress {
+                            Some("Wait for the current run to finish or interrupt it first.".to_string())
+                        } else {
+                            None
+                        }
+                    });
+                (
+                    ai_publish_blocker,
+                    ai_publish_disabled,
+                    ai_open_pr_disabled,
+                    ai_managed_worktree_target,
+                    ai_delete_worktree_blocker,
+                )
+            } else {
+                (None, true, true, None, None)
+            };
             let terminal_cwd_label = self
                 .ai_terminal_session
                 .cwd
@@ -471,6 +504,7 @@ impl DiffViewer {
         };
 
         let state = AiVisibleFrameState {
+            workspace_kind,
             project_count,
             visible_thread_count,
             threads_loading,
@@ -519,6 +553,7 @@ impl DiffViewer {
         for section in sections {
             rows.push(AiThreadSidebarRow {
                 kind: AiThreadSidebarRowKind::ProjectHeader {
+                    workspace_kind: section.workspace_kind,
                     project_root: section.project_root.clone(),
                     project_label: section.project_label.clone(),
                     total_thread_count: section.total_thread_count,
@@ -527,6 +562,7 @@ impl DiffViewer {
             if section.threads.is_empty() {
                 rows.push(AiThreadSidebarRow {
                     kind: AiThreadSidebarRowKind::EmptyProject {
+                        workspace_kind: section.workspace_kind,
                         project_root: section.project_root.clone(),
                     },
                 });
@@ -544,6 +580,7 @@ impl DiffViewer {
             if section.hidden_thread_count > 0 || section.expanded {
                 rows.push(AiThreadSidebarRow {
                     kind: AiThreadSidebarRowKind::ProjectFooter {
+                        workspace_kind: section.workspace_kind,
                         project_root: section.project_root.clone(),
                         hidden_thread_count: section.hidden_thread_count,
                         expanded: section.expanded,
@@ -572,13 +609,15 @@ impl DiffViewer {
             self.project_path.as_deref(),
             self.repo_root.as_deref(),
         );
+        let chats_root = self.ai_chats_root_path();
         self.ai_state_snapshot
             .threads
             .get(thread_id)
             .filter(|thread| {
-                ai_workspace_project_root_for_thread_root(
+                ai_workspace_section_root_for_thread_root(
                     std::path::Path::new(thread.cwd.as_str()),
                     workspace_project_roots.as_slice(),
+                    chats_root.as_deref(),
                 )
                 .is_some()
             })
@@ -592,9 +631,10 @@ impl DiffViewer {
                             .threads
                             .get(thread_id)
                             .filter(|thread| {
-                                ai_workspace_project_root_for_thread_root(
+                                ai_workspace_section_root_for_thread_root(
                                     std::path::Path::new(thread.cwd.as_str()),
                                     workspace_project_roots.as_slice(),
+                                    chats_root.as_deref(),
                                 )
                                 .is_some()
                             })

--- a/crates/hunk-desktop/src/app/controller/ai/core_workspace.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/core_workspace.rs
@@ -36,6 +36,7 @@ impl DiffViewer {
             } else {
                 current_thread_workspace_root
                     .clone()
+                    .or_else(|| fallback_workspace_key.as_deref().map(std::path::PathBuf::from))
                     .or_else(|| self.ai_draft_workspace_root())
             };
         let workspace_key = workspace_root
@@ -99,7 +100,7 @@ impl DiffViewer {
             return Some(target.root.clone());
         }
 
-        self.primary_repo_root()
+        self.primary_repo_root().or_else(|| self.ai_chats_root_path())
     }
 
     fn resolve_ai_default_worktree_base_branch_name(&self) -> Option<String> {
@@ -187,6 +188,9 @@ impl DiffViewer {
         }
 
         let workspace_root = workspace_root?;
+        if self.ai_workspace_kind_for_root(workspace_root) == AiWorkspaceKind::Chats {
+            return None;
+        }
         let workspace_project_roots = ai_workspace_project_roots(
             self.state.workspace_project_paths.as_slice(),
             self.project_path.as_deref(),
@@ -200,6 +204,28 @@ impl DiffViewer {
 
     fn ai_workspace_key(&self) -> Option<String> {
         self.resolve_ai_current_state().workspace_key
+    }
+
+    pub(crate) fn ai_chats_root_path(&self) -> Option<std::path::PathBuf> {
+        crate::app::ai_paths::resolve_ai_chats_root_path()
+    }
+
+    pub(crate) fn ai_workspace_kind_for_root(
+        &self,
+        workspace_root: &std::path::Path,
+    ) -> AiWorkspaceKind {
+        resolved_ai_workspace_kind_for_root(
+            Some(workspace_root),
+            self.ai_chats_root_path().as_deref(),
+        )
+    }
+
+    pub(crate) fn current_ai_workspace_kind(&self) -> AiWorkspaceKind {
+        let resolved = self.resolve_ai_current_state();
+        resolved_ai_workspace_kind_for_root(
+            resolved.workspace_root.as_deref(),
+            self.ai_chats_root_path().as_deref(),
+        )
     }
 
     fn sync_ai_workspace_target_from_catalog(&mut self, _: &mut Context<Self>) {
@@ -249,10 +275,18 @@ impl DiffViewer {
             return "Primary Checkout".to_string();
         };
 
+        if self.ai_workspace_kind_for_root(workspace_root) == AiWorkspaceKind::Chats {
+            return "Chats".to_string();
+        }
+
         self.ai_workspace_label_for_root(workspace_root)
     }
 
     pub(crate) fn ai_workspace_label_for_root(&self, workspace_root: &std::path::Path) -> String {
+        if self.ai_workspace_kind_for_root(workspace_root) == AiWorkspaceKind::Chats {
+            return "Chats".to_string();
+        }
+
         workspace_target_summary_for_root(
             workspace_root,
             &self.workspace_targets,

--- a/crates/hunk-desktop/src/app/controller/ai/followup_prompts.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/followup_prompts.rs
@@ -473,6 +473,9 @@ impl DiffViewer {
     }
 
     pub(super) fn ai_cycle_composer_mode(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            return;
+        }
         match ai_cycle_composer_mode_target(
             self.ai_review_mode_active,
             self.ai_selected_collaboration_mode,

--- a/crates/hunk-desktop/src/app/controller/ai/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/helpers.rs
@@ -176,7 +176,7 @@ fn ai_workspace_section_root_for_thread_root(
     workspace_project_roots: &[std::path::PathBuf],
     chats_root: Option<&std::path::Path>,
 ) -> Option<std::path::PathBuf> {
-    if chats_root == Some(thread_workspace_root) {
+    if crate::app::ai_paths::is_ai_chats_workspace_path(thread_workspace_root) {
         return chats_root.map(std::path::Path::to_path_buf);
     }
 
@@ -185,9 +185,9 @@ fn ai_workspace_section_root_for_thread_root(
 
 fn resolved_ai_workspace_kind_for_root(
     workspace_root: Option<&std::path::Path>,
-    chats_root: Option<&std::path::Path>,
+    _: Option<&std::path::Path>,
 ) -> AiWorkspaceKind {
-    if workspace_root.is_some() && workspace_root == chats_root {
+    if workspace_root.is_some_and(crate::app::ai_paths::is_ai_chats_workspace_path) {
         AiWorkspaceKind::Chats
     } else {
         AiWorkspaceKind::Project
@@ -195,9 +195,9 @@ fn resolved_ai_workspace_kind_for_root(
 }
 
 fn is_ai_chats_workspace_key(workspace_key: Option<&str>) -> bool {
-    let chats_key = crate::app::ai_paths::resolve_ai_chats_root_path()
-        .map(|path| path.to_string_lossy().to_string());
-    workspace_key.is_some_and(|workspace_key| chats_key.as_deref() == Some(workspace_key))
+    workspace_key
+        .map(std::path::Path::new)
+        .is_some_and(crate::app::ai_paths::is_ai_chats_workspace_path)
 }
 
 fn ai_visible_thread_sections(
@@ -423,7 +423,7 @@ fn ai_thread_start_mode_for_workspace(
     workspace_targets: &[hunk_git::worktree::WorkspaceTargetSummary],
     thread_cwd: &std::path::Path,
 ) -> Option<AiNewThreadStartMode> {
-    if crate::app::ai_paths::resolve_ai_chats_root_path().as_deref() == Some(thread_cwd) {
+    if crate::app::ai_paths::is_ai_chats_workspace_path(thread_cwd) {
         return None;
     }
 

--- a/crates/hunk-desktop/src/app/controller/ai/helpers.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/helpers.rs
@@ -64,18 +64,21 @@ fn merged_ai_visible_threads(
     repo_root: Option<&std::path::Path>,
 ) -> Vec<ThreadSummary> {
     let mut threads_by_id = std::collections::BTreeMap::<String, ThreadSummary>::new();
-    let mut project_root_resolver = AiWorkspaceProjectRootResolver::new(
-        ai_workspace_project_roots(workspace_project_paths, project_path, repo_root),
-    );
+    let workspace_project_roots =
+        ai_workspace_project_roots(workspace_project_paths, project_path, repo_root);
+    let chats_root = crate::app::ai_paths::resolve_ai_chats_root_path();
 
     for thread in state_snapshot
         .threads
         .values()
         .filter(|thread| {
             thread.status != ThreadLifecycleStatus::Archived
-                && project_root_resolver
-                    .resolve(std::path::Path::new(thread.cwd.as_str()))
-                    .is_some()
+                && ai_workspace_section_root_for_thread_root(
+                    std::path::Path::new(thread.cwd.as_str()),
+                    workspace_project_roots.as_slice(),
+                    chats_root.as_deref(),
+                )
+                .is_some()
         })
     {
         threads_by_id.insert(thread.id.clone(), thread.clone());
@@ -83,9 +86,12 @@ fn merged_ai_visible_threads(
 
     for (workspace_key, state) in workspace_states {
         if state_snapshot_workspace_key == Some(workspace_key.as_str())
-            || project_root_resolver
-                .resolve(std::path::Path::new(workspace_key.as_str()))
-                .is_none()
+            || ai_workspace_section_root_for_thread_root(
+                std::path::Path::new(workspace_key.as_str()),
+                workspace_project_roots.as_slice(),
+                chats_root.as_deref(),
+            )
+            .is_none()
         {
             continue;
         }
@@ -95,9 +101,12 @@ fn merged_ai_visible_threads(
             .values()
             .filter(|thread| {
                 thread.status != ThreadLifecycleStatus::Archived
-                    && project_root_resolver
-                        .resolve(std::path::Path::new(thread.cwd.as_str()))
-                        .is_some()
+                    && ai_workspace_section_root_for_thread_root(
+                        std::path::Path::new(thread.cwd.as_str()),
+                        workspace_project_roots.as_slice(),
+                        chats_root.as_deref(),
+                    )
+                    .is_some()
             })
         {
             let replace_existing = threads_by_id
@@ -162,6 +171,35 @@ fn ai_workspace_project_root_for_thread_root(
         .cloned()
 }
 
+fn ai_workspace_section_root_for_thread_root(
+    thread_workspace_root: &std::path::Path,
+    workspace_project_roots: &[std::path::PathBuf],
+    chats_root: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    if chats_root == Some(thread_workspace_root) {
+        return chats_root.map(std::path::Path::to_path_buf);
+    }
+
+    ai_workspace_project_root_for_thread_root(thread_workspace_root, workspace_project_roots)
+}
+
+fn resolved_ai_workspace_kind_for_root(
+    workspace_root: Option<&std::path::Path>,
+    chats_root: Option<&std::path::Path>,
+) -> AiWorkspaceKind {
+    if workspace_root.is_some() && workspace_root == chats_root {
+        AiWorkspaceKind::Chats
+    } else {
+        AiWorkspaceKind::Project
+    }
+}
+
+fn is_ai_chats_workspace_key(workspace_key: Option<&str>) -> bool {
+    let chats_key = crate::app::ai_paths::resolve_ai_chats_root_path()
+        .map(|path| path.to_string_lossy().to_string());
+    workspace_key.is_some_and(|workspace_key| chats_key.as_deref() == Some(workspace_key))
+}
+
 fn ai_visible_thread_sections(
     threads: Vec<ThreadSummary>,
     workspace_project_paths: &[std::path::PathBuf],
@@ -170,23 +208,51 @@ fn ai_visible_thread_sections(
     expanded_project_roots: &BTreeSet<String>,
 ) -> Vec<AiVisibleThreadProjectSection> {
     let project_roots = ai_workspace_project_roots(workspace_project_paths, project_path, repo_root);
-    let mut project_root_resolver = AiWorkspaceProjectRootResolver::new(project_roots.clone());
+    let chats_root = crate::app::ai_paths::resolve_ai_chats_root_path();
     let mut threads_by_project = std::collections::BTreeMap::<
         std::path::PathBuf,
         Vec<ThreadSummary>,
     >::new();
 
     for thread in threads {
-        if let Some(project_root) =
-            project_root_resolver.resolve(std::path::Path::new(thread.cwd.as_str()))
+        if let Some(project_root) = ai_workspace_section_root_for_thread_root(
+            std::path::Path::new(thread.cwd.as_str()),
+            project_roots.as_slice(),
+            chats_root.as_deref(),
+        )
         {
             threads_by_project.entry(project_root).or_default().push(thread);
         }
     }
 
-    project_roots
-        .into_iter()
-        .map(|project_root| {
+    let mut sections = Vec::new();
+
+    if let Some(chats_root) = chats_root {
+        let expanded = expanded_project_roots.contains(chats_root.to_string_lossy().as_ref());
+        let all_threads = threads_by_project.remove(&chats_root).unwrap_or_default();
+        let total_thread_count = all_threads.len();
+        let visible_threads = if expanded {
+            all_threads.clone()
+        } else {
+            all_threads
+                .iter()
+                .take(AI_THREAD_SIDEBAR_DEFAULT_VISIBLE_THREADS_PER_PROJECT)
+                .cloned()
+                .collect()
+        };
+
+        sections.push(AiVisibleThreadProjectSection {
+            workspace_kind: AiWorkspaceKind::Chats,
+            project_label: "Chats".to_string(),
+            hidden_thread_count: total_thread_count.saturating_sub(visible_threads.len()),
+            total_thread_count,
+            expanded,
+            project_root: chats_root,
+            threads: visible_threads,
+        });
+    }
+
+    sections.extend(project_roots.into_iter().map(|project_root| {
             let expanded = expanded_project_roots
                 .contains(project_root.to_string_lossy().as_ref());
             let all_threads = threads_by_project.remove(&project_root).unwrap_or_default();
@@ -202,6 +268,7 @@ fn ai_visible_thread_sections(
             };
 
             AiVisibleThreadProjectSection {
+                workspace_kind: AiWorkspaceKind::Project,
                 project_label: crate::app::project_picker::project_display_name(
                     project_root.as_path(),
                 ),
@@ -211,8 +278,9 @@ fn ai_visible_thread_sections(
                 project_root,
                 threads: visible_threads,
             }
-        })
-        .collect()
+        }));
+
+    sections
 }
 
 pub(crate) const AI_AUTH_REQUIRED_MESSAGE: &str =
@@ -253,36 +321,6 @@ fn ai_workspace_project_root_identity(path: &std::path::Path) -> Option<std::pat
     hunk_git::worktree::primary_repo_root(path)
         .ok()
         .or_else(|| Some(path.to_path_buf()))
-}
-
-struct AiWorkspaceProjectRootResolver {
-    workspace_project_roots: Vec<std::path::PathBuf>,
-    resolved_project_roots:
-        std::collections::BTreeMap<std::path::PathBuf, Option<std::path::PathBuf>>,
-}
-
-impl AiWorkspaceProjectRootResolver {
-    fn new(workspace_project_roots: Vec<std::path::PathBuf>) -> Self {
-        Self {
-            workspace_project_roots,
-            resolved_project_roots: BTreeMap::new(),
-        }
-    }
-
-    fn resolve(&mut self, workspace_root: &std::path::Path) -> Option<std::path::PathBuf> {
-        let workspace_root = workspace_root.to_path_buf();
-        if let Some(project_root) = self.resolved_project_roots.get(&workspace_root) {
-            return project_root.clone();
-        }
-
-        let resolved = ai_workspace_project_root_for_thread_root(
-            workspace_root.as_path(),
-            self.workspace_project_roots.as_slice(),
-        );
-        self.resolved_project_roots
-            .insert(workspace_root, resolved.clone());
-        resolved
-    }
 }
 
 fn workspace_mad_max_mode(state: &AppState, workspace_key: Option<&str>) -> bool {
@@ -385,6 +423,10 @@ fn ai_thread_start_mode_for_workspace(
     workspace_targets: &[hunk_git::worktree::WorkspaceTargetSummary],
     thread_cwd: &std::path::Path,
 ) -> Option<AiNewThreadStartMode> {
+    if crate::app::ai_paths::resolve_ai_chats_root_path().as_deref() == Some(thread_cwd) {
+        return None;
+    }
+
     if let Some(target) = workspace_targets
         .iter()
         .find(|target| target.root.as_path() == thread_cwd)
@@ -401,13 +443,21 @@ fn ai_thread_start_mode_for_workspace(
 
     hunk_git::worktree::primary_repo_root(thread_cwd)
         .ok()
-        .or_else(|| repo_root.map(std::path::Path::to_path_buf))
         .map(|primary_root| {
             if primary_root.as_path() == thread_cwd {
                 AiNewThreadStartMode::Local
             } else {
                 AiNewThreadStartMode::Worktree
             }
+        })
+        .or_else(|| {
+            repo_root.map(|repo_root| {
+                if repo_root == thread_cwd {
+                    AiNewThreadStartMode::Local
+                } else {
+                    AiNewThreadStartMode::Worktree
+                }
+            })
         })
 }
 
@@ -1039,14 +1089,20 @@ fn resolved_ai_thread_session_state(
     thread_id: Option<&str>,
     workspace_key: Option<&str>,
 ) -> AiThreadSessionState {
-    thread_id
+    let mut resolved = thread_id
         .and_then(|thread_id| state.ai_thread_session_overrides.get(thread_id).cloned())
         .or_else(|| {
             workspace_key.and_then(|workspace| {
                 state.ai_workspace_session_overrides.get(workspace).cloned()
             })
         })
-        .unwrap_or_else(AiThreadSessionState::preferred_defaults)
+        .unwrap_or_else(AiThreadSessionState::preferred_defaults);
+
+    if is_ai_chats_workspace_key(workspace_key) {
+        resolved.collaboration_mode = AiCollaborationModeSelection::Default;
+    }
+
+    resolved
 }
 
 fn resolved_ai_turn_session_overrides(

--- a/crates/hunk-desktop/src/app/controller/ai/runtime.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime.rs
@@ -509,6 +509,64 @@ impl DiffViewer {
         session_overrides: AiTurnSessionOverrides,
         cx: &mut Context<Self>,
     ) -> bool {
+        let Some(draft_workspace_root) = self.ai_draft_workspace_root() else {
+            self.set_current_ai_composer_status(
+                "Open a workspace before starting an AI thread.",
+                cx,
+            );
+            cx.notify();
+            return false;
+        };
+
+        if self.ai_workspace_kind_for_root(draft_workspace_root.as_path()) == AiWorkspaceKind::Chats
+        {
+            let Some(chats_root) = crate::app::ai_paths::ensure_ai_chats_root_path()
+                .or_else(crate::app::ai_paths::resolve_ai_chats_root_path)
+            else {
+                self.set_current_ai_composer_status(
+                    "Failed to prepare the Chats workspace.",
+                    cx,
+                );
+                cx.notify();
+                return false;
+            };
+            let workspace_key = chats_root.to_string_lossy().to_string();
+            let previous_workspace_key = self.ai_workspace_key();
+            self.ai_draft_workspace_root_override = Some(chats_root);
+            self.ai_draft_workspace_target_id = None;
+            self.ai_worktree_base_branch_name = None;
+            self.seed_ai_workspace_state_for(workspace_key.as_str());
+            self.ai_handle_workspace_change_to(
+                previous_workspace_key,
+                Some(workspace_key.clone()),
+                cx,
+            );
+            if let Some(pending) = self.ai_pending_thread_start.as_mut() {
+                pending.workspace_key = workspace_key;
+            }
+            if self.send_ai_worker_command(
+                AiWorkerCommand::StartThread {
+                    prompt,
+                    local_image_paths,
+                    selected_skills,
+                    skill_bindings,
+                    session_overrides,
+                },
+                cx,
+            ) {
+                self.clear_current_ai_composer_status();
+                self.ai_pending_new_thread_selection = true;
+                return true;
+            }
+
+            self.set_current_ai_composer_status(
+                "Chats workspace prepared, but failed to start thread.",
+                cx,
+            );
+            self.restore_ai_new_thread_draft_after_failure(cx);
+            return false;
+        }
+
         if self.git_controls_busy() {
             self.set_current_ai_composer_status(
                 "Wait for the active workspace action to finish.",
@@ -518,14 +576,7 @@ impl DiffViewer {
             return false;
         }
 
-        let Some(repo_root) = self.ai_draft_workspace_root() else {
-            self.set_current_ai_composer_status(
-                "Open a workspace before starting an AI thread.",
-                cx,
-            );
-            cx.notify();
-            return false;
-        };
+        let repo_root = draft_workspace_root;
 
         let start_mode = self.ai_new_thread_start_mode;
         let selected_base_branch_name = self
@@ -835,6 +886,10 @@ impl DiffViewer {
 
     fn sync_ai_session_selection_from_state(&mut self) {
         let resolved = { self.resolve_ai_current_state() };
+        let workspace_kind = resolved_ai_workspace_kind_for_root(
+            resolved.workspace_root.as_deref(),
+            self.ai_chats_root_path().as_deref(),
+        );
         let persisted = {
             resolved_ai_thread_session_state(
                 &self.state,
@@ -855,10 +910,14 @@ impl DiffViewer {
             self.ai_selected_collaboration_mode = persisted.collaboration_mode;
             self.ai_selected_effort = selected_effort;
             self.ai_selected_service_tier = persisted.service_tier.unwrap_or_default();
-            self.ai_review_mode_active = resolved
-                .current_thread_id
-                .as_ref()
-                .is_some_and(|thread_id| self.ai_review_mode_thread_ids.contains(thread_id));
+            self.ai_review_mode_active = if workspace_kind == AiWorkspaceKind::Chats {
+                false
+            } else {
+                resolved
+                    .current_thread_id
+                    .as_ref()
+                    .is_some_and(|thread_id| self.ai_review_mode_thread_ids.contains(thread_id))
+            };
         }
     }
 
@@ -917,12 +976,15 @@ impl DiffViewer {
     }
 
     fn persist_ai_session_for_target(&mut self, thread_id: Option<&str>, workspace: Option<&str>) {
-        let session = AiThreadSessionState {
+        let mut session = AiThreadSessionState {
             model: self.ai_selected_model.clone(),
             effort: self.ai_selected_effort.clone(),
             collaboration_mode: self.ai_selected_collaboration_mode,
             service_tier: normalized_ai_service_tier_selection(self.ai_selected_service_tier),
         };
+        if is_ai_chats_workspace_key(workspace) {
+            session.collaboration_mode = AiCollaborationModeSelection::Default;
+        }
 
         if let Some(thread_id) = thread_id {
             if let Some(session) = normalized_thread_session_state(session) {

--- a/crates/hunk-desktop/src/app/controller/ai/runtime.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime.rs
@@ -520,8 +520,8 @@ impl DiffViewer {
 
         if self.ai_workspace_kind_for_root(draft_workspace_root.as_path()) == AiWorkspaceKind::Chats
         {
-            let Some(chats_root) = crate::app::ai_paths::ensure_ai_chats_root_path()
-                .or_else(crate::app::ai_paths::resolve_ai_chats_root_path)
+            let Some(chat_workspace_root) =
+                crate::app::ai_paths::allocate_ai_chat_thread_workspace_path()
             else {
                 self.set_current_ai_composer_status(
                     "Failed to prepare the Chats workspace.",
@@ -530,9 +530,9 @@ impl DiffViewer {
                 cx.notify();
                 return false;
             };
-            let workspace_key = chats_root.to_string_lossy().to_string();
+            let workspace_key = chat_workspace_root.to_string_lossy().to_string();
             let previous_workspace_key = self.ai_workspace_key();
-            self.ai_draft_workspace_root_override = Some(chats_root);
+            self.ai_draft_workspace_root_override = Some(chat_workspace_root);
             self.ai_draft_workspace_target_id = None;
             self.ai_worktree_base_branch_name = None;
             self.seed_ai_workspace_state_for(workspace_key.as_str());

--- a/crates/hunk-desktop/src/app/controller/ai/runtime.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime.rs
@@ -474,7 +474,7 @@ impl DiffViewer {
             return sent;
         }
 
-        let pending_thread_start =
+        self.ai_pending_thread_start =
             self.ai_workspace_key_for_draft()
                 .map(|workspace_key| AiPendingThreadStart {
                     workspace_key,
@@ -494,8 +494,9 @@ impl DiffViewer {
             cx,
         );
         if started {
-            self.ai_pending_thread_start = pending_thread_start;
             cx.notify();
+        } else {
+            self.ai_pending_thread_start = None;
         }
         started
     }

--- a/crates/hunk-desktop/src/app/controller/ai/runtime_composer.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime_composer.rs
@@ -1,4 +1,19 @@
 impl DiffViewer {
+    fn cleanup_failed_chat_workspace(
+        &mut self,
+        chats_root_key: &str,
+        pending_workspace_key: &str,
+        cx: &mut Context<Self>,
+    ) {
+        self.shutdown_ai_runtime_for_workspace_blocking(pending_workspace_key);
+        self.ai_forget_deleted_workspace_state(pending_workspace_key, cx);
+        self.ai_draft_workspace_root_override = Some(std::path::PathBuf::from(chats_root_key));
+        self.ai_draft_workspace_target_id = None;
+        self.ai_worktree_base_branch_name = None;
+        self.restore_ai_workspace_state_for_key(Some(chats_root_key));
+        let _ = std::fs::remove_dir_all(pending_workspace_key);
+    }
+
     fn current_ai_composer_status_key(&self) -> AiComposerStatusKey {
         self.current_ai_composer_draft_key()
             .map(AiComposerStatusKey::Draft)
@@ -238,9 +253,23 @@ impl DiffViewer {
             self.ai_new_thread_draft_active = true;
         }
         self.ai_pending_new_thread_selection = false;
-        let Some(pending) = self.ai_pending_thread_start.take() else {
+        let Some(mut pending) = self.ai_pending_thread_start.take() else {
             return;
         };
+        if let Some((chats_root_key, pending_workspace_key)) =
+            failed_chat_workspace_cleanup_target(
+                self.ai_chats_root_path().as_deref(),
+                pending.workspace_key.as_str(),
+                pending.thread_id.as_deref(),
+            )
+        {
+            self.cleanup_failed_chat_workspace(
+                chats_root_key.as_str(),
+                pending_workspace_key.as_str(),
+                cx,
+            );
+            pending.workspace_key = chats_root_key;
+        }
         let current_workspace_key = self.ai_workspace_key_for_draft();
         if current_workspace_key.as_deref() != Some(pending.workspace_key.as_str()) {
             self.ai_pending_thread_start = Some(pending);
@@ -274,6 +303,29 @@ impl DiffViewer {
         self.ai_composer_activity_elapsed_second = next;
         true
     }
+}
+
+fn failed_chat_workspace_cleanup_target(
+    chats_root: Option<&std::path::Path>,
+    pending_workspace_key: &str,
+    pending_thread_id: Option<&str>,
+) -> Option<(String, String)> {
+    if pending_thread_id.is_some() {
+        return None;
+    }
+
+    let chats_root = chats_root?;
+    let pending_workspace = std::path::PathBuf::from(pending_workspace_key);
+    if pending_workspace == chats_root
+        || !crate::app::ai_paths::is_ai_chats_workspace_path(pending_workspace.as_path())
+    {
+        return None;
+    }
+
+    Some((
+        chats_root.to_string_lossy().to_string(),
+        pending_workspace_key.to_string(),
+    ))
 }
 
 fn composer_status_message_for_visible_target<'a>(

--- a/crates/hunk-desktop/src/app/controller/ai/terminal.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/terminal.rs
@@ -85,7 +85,8 @@ impl DiffViewer {
 
     pub(crate) fn active_workspace_terminal_kind(&self) -> Option<WorkspaceTerminalKind> {
         match self.workspace_view_mode {
-            WorkspaceViewMode::Ai => Some(WorkspaceTerminalKind::Ai),
+            WorkspaceViewMode::Ai => (self.current_ai_workspace_kind() != AiWorkspaceKind::Chats)
+                .then_some(WorkspaceTerminalKind::Ai),
             WorkspaceViewMode::Files
             | WorkspaceViewMode::Diff
             | WorkspaceViewMode::GitWorkspace => Some(WorkspaceTerminalKind::Files),
@@ -401,7 +402,7 @@ impl DiffViewer {
         cx: &mut Context<Self>,
     ) {
         match self.workspace_view_mode {
-            WorkspaceViewMode::Ai => self.toggle_ai_terminal_drawer(cx),
+            WorkspaceViewMode::Ai => self.ai_toggle_terminal_drawer_action(cx),
             WorkspaceViewMode::Files
             | WorkspaceViewMode::Diff
             | WorkspaceViewMode::GitWorkspace => {
@@ -411,6 +412,14 @@ impl DiffViewer {
     }
 
     pub(super) fn ai_toggle_terminal_drawer_action(&mut self, cx: &mut Context<Self>) {
+        if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+            self.set_current_ai_composer_status(
+                "Terminal is unavailable in Chats.",
+                cx,
+            );
+            cx.notify();
+            return;
+        }
         self.toggle_ai_terminal_drawer(cx);
     }
 

--- a/crates/hunk-desktop/src/app/controller/ai/tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests.rs
@@ -160,6 +160,7 @@ mod ai_tests {
     #[cfg(target_os = "windows")]
     use std::ffi::OsString;
     use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
     use std::sync::mpsc;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -335,6 +336,38 @@ mod ai_tests {
             additional_speed_tiers: Vec::new(),
             is_default,
         }
+    }
+
+    fn ai_test_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_temp_hunk_home<T>(test_name: &str, f: impl FnOnce(PathBuf) -> T) -> T {
+        let _guard = ai_test_env_lock()
+            .lock()
+            .expect("ai test env lock should be available");
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let temp_home = std::env::temp_dir().join(format!("hunk-ai-test-{test_name}-{unique}"));
+        let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
+        unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &temp_home) };
+        let _ = std::fs::remove_dir_all(&temp_home);
+        std::fs::create_dir_all(&temp_home).expect("temp hunk home should be created");
+
+        let result = f(temp_home.clone());
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, value)
+            },
+            None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
+        }
+        let _ = std::fs::remove_dir_all(&temp_home);
+
+        result
     }
 
     include!("tests/workspace_state.rs");

--- a/crates/hunk-desktop/src/app/controller/ai/tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests.rs
@@ -27,6 +27,7 @@ mod ai_tests {
     use super::ai_timeline_row_supports_inline_review;
     use super::AI_AUTH_REQUIRED_MESSAGE;
     use super::ai_workspace_catalog_inputs_from_target_sets;
+    use super::ai_visible_thread_sections;
     use super::ai_composer_draft_key;
     use super::ai_composer_prompt_for_target;
     use super::ai_composer_retained_thread_ids;
@@ -101,6 +102,7 @@ mod ai_tests {
     use super::AiComposerModeTarget;
     use super::AiComposerShortcut;
     use crate::app::ai_composer_completion::merge_rebased_ai_composer_skill_bindings;
+    use crate::app::ai_paths::resolve_ai_chats_root_path;
     use crate::app::ai_runtime::AiConnectionState;
     use crate::app::ai_workspace_session;
     use crate::app::ai_workspace_surface::ai_workspace_selectable_text_context_menu_target;
@@ -130,6 +132,7 @@ mod ai_tests {
     use crate::app::AiThreadTitleRefreshState;
     use crate::app::AiTimelineRow;
     use crate::app::AiTimelineRowSource;
+    use crate::app::AiWorkspaceKind;
     use crate::app::AiWorkspaceState;
     use crate::app::DiffViewer;
     use crate::app::WorkspaceViewMode;

--- a/crates/hunk-desktop/src/app/controller/ai/tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests.rs
@@ -161,7 +161,6 @@ mod ai_tests {
     #[cfg(target_os = "windows")]
     use std::ffi::OsString;
     use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
     use std::sync::mpsc;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -339,15 +338,8 @@ mod ai_tests {
         }
     }
 
-    fn ai_test_env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
     fn with_temp_hunk_home<T>(test_name: &str, f: impl FnOnce(PathBuf) -> T) -> T {
-        let _guard = ai_test_env_lock()
-            .lock()
-            .expect("ai test env lock should be available");
+        let _guard = crate::app::ai_paths::lock_hunk_home_test_env();
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time should be after epoch")

--- a/crates/hunk-desktop/src/app/controller/ai/tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests.rs
@@ -95,6 +95,7 @@ mod ai_tests {
     use super::timeline_turn_ids_by_thread;
     use super::timeline_visible_row_ids_for_turns;
     use super::timeline_visible_turn_ids;
+    use super::failed_chat_workspace_cleanup_target;
     use super::workspace_target_summary_for_root;
     use super::workspace_branch_name_for_root;
     use super::workspace_include_hidden_models;

--- a/crates/hunk-desktop/src/app/controller/ai/tests/runtime_path_and_session.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests/runtime_path_and_session.rs
@@ -576,6 +576,87 @@ fn resolved_ai_thread_session_state_uses_preferred_defaults_without_overrides() 
 }
 
 #[test]
+fn resolved_ai_thread_session_state_clamps_chats_to_default_mode() {
+    let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+    let chats_key = chats_root.to_string_lossy().to_string();
+    let mut state = AppState::default();
+    state.ai_workspace_session_overrides.insert(
+        chats_key.clone(),
+        AiThreadSessionState {
+            model: Some("gpt-5.4".to_string()),
+            effort: Some("medium".to_string()),
+            collaboration_mode: AiCollaborationModeSelection::Plan,
+            service_tier: Some(AiServiceTierSelection::Fast),
+        },
+    );
+
+    assert_eq!(
+        resolved_ai_thread_session_state(&state, None, Some(chats_key.as_str())),
+        AiThreadSessionState {
+            model: Some("gpt-5.4".to_string()),
+            effort: Some("medium".to_string()),
+            collaboration_mode: AiCollaborationModeSelection::Default,
+            service_tier: Some(AiServiceTierSelection::Fast),
+        },
+    );
+}
+
+#[test]
+fn ai_thread_start_mode_for_workspace_does_not_treat_chats_as_repo_workspace() {
+    let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+
+    assert_eq!(
+        ai_thread_start_mode_for_workspace(
+            Some(std::path::Path::new("/repo")),
+            &[],
+            chats_root.as_path(),
+        ),
+        None,
+    );
+}
+
+#[test]
+fn ai_visible_thread_sections_prepend_global_chats_section() {
+    let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+    let sections = ai_visible_thread_sections(
+        vec![
+            ThreadSummary {
+                id: "chat-1".to_string(),
+                cwd: chats_root.to_string_lossy().to_string(),
+                title: Some("Chat".to_string()),
+                status: ThreadLifecycleStatus::Active,
+                created_at: 2,
+                updated_at: 2,
+                last_sequence: 2,
+            },
+            ThreadSummary {
+                id: "repo-1".to_string(),
+                cwd: "/repo".to_string(),
+                title: Some("Repo Thread".to_string()),
+                status: ThreadLifecycleStatus::Active,
+                created_at: 1,
+                updated_at: 1,
+                last_sequence: 1,
+            },
+        ],
+        &[PathBuf::from("/repo")],
+        None,
+        None,
+        &BTreeSet::default(),
+    );
+
+    assert_eq!(sections.len(), 2);
+    assert_eq!(sections[0].workspace_kind, AiWorkspaceKind::Chats);
+    assert_eq!(sections[0].project_label, "Chats");
+    assert_eq!(sections[0].threads.len(), 1);
+    assert_eq!(sections[0].threads[0].id, "chat-1");
+    assert_eq!(sections[1].workspace_kind, AiWorkspaceKind::Project);
+    assert_eq!(sections[1].project_root, PathBuf::from("/repo"));
+    assert_eq!(sections[1].threads.len(), 1);
+    assert_eq!(sections[1].threads[0].id, "repo-1");
+}
+
+#[test]
 fn resolved_ai_turn_session_overrides_prefers_queued_thread_session() {
     let models = vec![
         ai_model(

--- a/crates/hunk-desktop/src/app/controller/ai/tests/runtime_path_and_session.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests/runtime_path_and_session.rs
@@ -577,83 +577,90 @@ fn resolved_ai_thread_session_state_uses_preferred_defaults_without_overrides() 
 
 #[test]
 fn resolved_ai_thread_session_state_clamps_chats_to_default_mode() {
-    let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
-    let chats_key = chats_root.to_string_lossy().to_string();
-    let mut state = AppState::default();
-    state.ai_workspace_session_overrides.insert(
-        chats_key.clone(),
-        AiThreadSessionState {
-            model: Some("gpt-5.4".to_string()),
-            effort: Some("medium".to_string()),
-            collaboration_mode: AiCollaborationModeSelection::Plan,
-            service_tier: Some(AiServiceTierSelection::Fast),
-        },
-    );
+    with_temp_hunk_home("session-clamps-chats", |_| {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+        let chats_key = chats_root.join("chat-1").to_string_lossy().to_string();
+        let mut state = AppState::default();
+        state.ai_workspace_session_overrides.insert(
+            chats_key.clone(),
+            AiThreadSessionState {
+                model: Some("gpt-5.4".to_string()),
+                effort: Some("medium".to_string()),
+                collaboration_mode: AiCollaborationModeSelection::Plan,
+                service_tier: Some(AiServiceTierSelection::Fast),
+            },
+        );
 
-    assert_eq!(
-        resolved_ai_thread_session_state(&state, None, Some(chats_key.as_str())),
-        AiThreadSessionState {
-            model: Some("gpt-5.4".to_string()),
-            effort: Some("medium".to_string()),
-            collaboration_mode: AiCollaborationModeSelection::Default,
-            service_tier: Some(AiServiceTierSelection::Fast),
-        },
-    );
+        assert_eq!(
+            resolved_ai_thread_session_state(&state, None, Some(chats_key.as_str())),
+            AiThreadSessionState {
+                model: Some("gpt-5.4".to_string()),
+                effort: Some("medium".to_string()),
+                collaboration_mode: AiCollaborationModeSelection::Default,
+                service_tier: Some(AiServiceTierSelection::Fast),
+            },
+        );
+    });
 }
 
 #[test]
 fn ai_thread_start_mode_for_workspace_does_not_treat_chats_as_repo_workspace() {
-    let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+    with_temp_hunk_home("thread-start-mode-chats", |_| {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
 
-    assert_eq!(
-        ai_thread_start_mode_for_workspace(
-            Some(std::path::Path::new("/repo")),
-            &[],
-            chats_root.as_path(),
-        ),
-        None,
-    );
+        assert_eq!(
+            ai_thread_start_mode_for_workspace(
+                Some(std::path::Path::new("/repo")),
+                &[],
+                chats_root.join("chat-1").as_path(),
+            ),
+            None,
+        );
+    });
 }
 
 #[test]
 fn ai_visible_thread_sections_prepend_global_chats_section() {
-    let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
-    let sections = ai_visible_thread_sections(
-        vec![
-            ThreadSummary {
-                id: "chat-1".to_string(),
-                cwd: chats_root.to_string_lossy().to_string(),
-                title: Some("Chat".to_string()),
-                status: ThreadLifecycleStatus::Active,
-                created_at: 2,
-                updated_at: 2,
-                last_sequence: 2,
-            },
-            ThreadSummary {
-                id: "repo-1".to_string(),
-                cwd: "/repo".to_string(),
-                title: Some("Repo Thread".to_string()),
-                status: ThreadLifecycleStatus::Active,
-                created_at: 1,
-                updated_at: 1,
-                last_sequence: 1,
-            },
-        ],
-        &[PathBuf::from("/repo")],
-        None,
-        None,
-        &BTreeSet::default(),
-    );
+    with_temp_hunk_home("visible-thread-sections-chats", |_| {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+        let sections = ai_visible_thread_sections(
+            vec![
+                ThreadSummary {
+                    id: "chat-1".to_string(),
+                    cwd: chats_root.join("chat-1").to_string_lossy().to_string(),
+                    title: Some("Chat".to_string()),
+                    status: ThreadLifecycleStatus::Active,
+                    created_at: 2,
+                    updated_at: 2,
+                    last_sequence: 2,
+                },
+                ThreadSummary {
+                    id: "repo-1".to_string(),
+                    cwd: "/repo".to_string(),
+                    title: Some("Repo Thread".to_string()),
+                    status: ThreadLifecycleStatus::Active,
+                    created_at: 1,
+                    updated_at: 1,
+                    last_sequence: 1,
+                },
+            ],
+            &[PathBuf::from("/repo")],
+            None,
+            None,
+            &BTreeSet::default(),
+        );
 
-    assert_eq!(sections.len(), 2);
-    assert_eq!(sections[0].workspace_kind, AiWorkspaceKind::Chats);
-    assert_eq!(sections[0].project_label, "Chats");
-    assert_eq!(sections[0].threads.len(), 1);
-    assert_eq!(sections[0].threads[0].id, "chat-1");
-    assert_eq!(sections[1].workspace_kind, AiWorkspaceKind::Project);
-    assert_eq!(sections[1].project_root, PathBuf::from("/repo"));
-    assert_eq!(sections[1].threads.len(), 1);
-    assert_eq!(sections[1].threads[0].id, "repo-1");
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].workspace_kind, AiWorkspaceKind::Chats);
+        assert_eq!(sections[0].project_label, "Chats");
+        assert_eq!(sections[0].project_root, chats_root);
+        assert_eq!(sections[0].threads.len(), 1);
+        assert_eq!(sections[0].threads[0].id, "chat-1");
+        assert_eq!(sections[1].workspace_kind, AiWorkspaceKind::Project);
+        assert_eq!(sections[1].project_root, PathBuf::from("/repo"));
+        assert_eq!(sections[1].threads.len(), 1);
+        assert_eq!(sections[1].threads[0].id, "repo-1");
+    });
 }
 
 #[test]

--- a/crates/hunk-desktop/src/app/controller/ai/tests/runtime_path_and_session.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests/runtime_path_and_session.rs
@@ -664,6 +664,49 @@ fn ai_visible_thread_sections_prepend_global_chats_section() {
 }
 
 #[test]
+fn failed_chat_workspace_cleanup_target_only_cleans_orphaned_chat_children() {
+    with_temp_hunk_home("failed-chat-cleanup-target", |_| {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+        let child = chats_root.join("chat-1");
+        let child_key = child.to_string_lossy().to_string();
+        let chats_key = chats_root.to_string_lossy().to_string();
+
+        assert_eq!(
+            failed_chat_workspace_cleanup_target(
+                Some(chats_root.as_path()),
+                child_key.as_str(),
+                None,
+            ),
+            Some((chats_key, child_key.clone())),
+        );
+        assert_eq!(
+            failed_chat_workspace_cleanup_target(
+                Some(chats_root.as_path()),
+                chats_root.to_string_lossy().as_ref(),
+                None,
+            ),
+            None,
+        );
+        assert_eq!(
+            failed_chat_workspace_cleanup_target(
+                Some(chats_root.as_path()),
+                child_key.as_str(),
+                Some("thread-1"),
+            ),
+            None,
+        );
+        assert_eq!(
+            failed_chat_workspace_cleanup_target(
+                Some(chats_root.as_path()),
+                "/repo",
+                None,
+            ),
+            None,
+        );
+    });
+}
+
+#[test]
 fn resolved_ai_turn_session_overrides_prefers_queued_thread_session() {
     let models = vec![
         ai_model(

--- a/crates/hunk-desktop/src/app/controller/ai/tests/workspace_state.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests/workspace_state.rs
@@ -888,167 +888,192 @@
 
     #[test]
     fn thread_catalog_workspace_roots_skip_visible_primary_checkout() {
-        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
-        let workspace_targets = vec![
-            workspace_target(
-                "primary",
-                WorkspaceTargetKind::PrimaryCheckout,
-                "/repo",
-                "Primary Checkout",
-            ),
-            workspace_target(
-                "worktree:task-1",
-                WorkspaceTargetKind::LinkedWorktree,
-                "/repo/worktrees/task-1",
-                "task-1",
-            ),
-            workspace_target(
-                "worktree:task-1-duplicate",
-                WorkspaceTargetKind::LinkedWorktree,
-                "/repo/worktrees/task-1",
-                "task-1",
-            ),
-            workspace_target(
-                "worktree:task-2",
-                WorkspaceTargetKind::LinkedWorktree,
-                "/repo/worktrees/task-2",
-                "task-2",
-            ),
-        ];
+        with_temp_hunk_home("catalog-roots-primary", |temp_home| {
+            let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+            let chat_a = chats_root.join("chat-a");
+            let chat_b = chats_root.join("chat-b");
+            std::fs::create_dir_all(&chat_a).expect("chat-a should exist");
+            std::fs::create_dir_all(&chat_b).expect("chat-b should exist");
 
-        let roots = ai_thread_catalog_workspace_roots(workspace_targets.as_slice(), Some("/repo"));
-        assert_eq!(
-            roots,
-            vec![
-                PathBuf::from("/repo/worktrees/task-1"),
-                PathBuf::from("/repo/worktrees/task-2"),
-                chats_root,
-            ]
-        );
+            let workspace_targets = vec![
+                workspace_target(
+                    "primary",
+                    WorkspaceTargetKind::PrimaryCheckout,
+                    "/repo",
+                    "Primary Checkout",
+                ),
+                workspace_target(
+                    "worktree:task-1",
+                    WorkspaceTargetKind::LinkedWorktree,
+                    "/repo/worktrees/task-1",
+                    "task-1",
+                ),
+                workspace_target(
+                    "worktree:task-1-duplicate",
+                    WorkspaceTargetKind::LinkedWorktree,
+                    "/repo/worktrees/task-1",
+                    "task-1",
+                ),
+                workspace_target(
+                    "worktree:task-2",
+                    WorkspaceTargetKind::LinkedWorktree,
+                    "/repo/worktrees/task-2",
+                    "task-2",
+                ),
+            ];
+
+            let roots =
+                ai_thread_catalog_workspace_roots(workspace_targets.as_slice(), Some("/repo"));
+            assert_eq!(
+                roots,
+                vec![
+                    PathBuf::from("/repo/worktrees/task-1"),
+                    PathBuf::from("/repo/worktrees/task-2"),
+                    chats_root,
+                    chat_a,
+                    chat_b,
+                ]
+            );
+            let _ = std::fs::remove_dir_all(temp_home);
+        });
     }
 
     #[test]
     fn thread_catalog_workspace_roots_still_skip_visible_worktree() {
-        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
-        let workspace_targets = vec![
-            workspace_target(
-                "primary",
-                WorkspaceTargetKind::PrimaryCheckout,
-                "/repo",
-                "Primary Checkout",
-            ),
-            workspace_target(
-                "worktree:task-1",
-                WorkspaceTargetKind::LinkedWorktree,
-                "/repo/worktrees/task-1",
-                "task-1",
-            ),
-            workspace_target(
-                "worktree:task-2",
-                WorkspaceTargetKind::LinkedWorktree,
-                "/repo/worktrees/task-2",
-                "task-2",
-            ),
-        ];
+        with_temp_hunk_home("catalog-roots-worktree", |_| {
+            let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+            let chat_a = chats_root.join("chat-a");
+            std::fs::create_dir_all(&chat_a).expect("chat-a should exist");
+            let workspace_targets = vec![
+                workspace_target(
+                    "primary",
+                    WorkspaceTargetKind::PrimaryCheckout,
+                    "/repo",
+                    "Primary Checkout",
+                ),
+                workspace_target(
+                    "worktree:task-1",
+                    WorkspaceTargetKind::LinkedWorktree,
+                    "/repo/worktrees/task-1",
+                    "task-1",
+                ),
+                workspace_target(
+                    "worktree:task-2",
+                    WorkspaceTargetKind::LinkedWorktree,
+                    "/repo/worktrees/task-2",
+                    "task-2",
+                ),
+            ];
 
-        let roots = ai_thread_catalog_workspace_roots(
-            workspace_targets.as_slice(),
-            Some("/repo/worktrees/task-1"),
-        );
-        assert_eq!(
-            roots,
-            vec![
-                PathBuf::from("/repo"),
-                PathBuf::from("/repo/worktrees/task-2"),
-                chats_root,
-            ]
-        );
+            let roots = ai_thread_catalog_workspace_roots(
+                workspace_targets.as_slice(),
+                Some("/repo/worktrees/task-1"),
+            );
+            assert_eq!(
+                roots,
+                vec![PathBuf::from("/repo"), PathBuf::from("/repo/worktrees/task-2"), chats_root, chat_a]
+            );
+        });
     }
 
     #[test]
     fn workspace_catalog_inputs_include_all_projects_and_skip_visible_workspace_root() {
-        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
-        let repo_a_targets = vec![
-            workspace_target(
-                "primary",
-                WorkspaceTargetKind::PrimaryCheckout,
-                "/repo-a",
-                "Primary Checkout",
-            ),
-            workspace_target(
-                "worktree:task-a",
-                WorkspaceTargetKind::LinkedWorktree,
-                "/repo-a/worktrees/task-a",
-                "task-a",
-            ),
-        ];
-        let repo_b_targets = vec![
-            workspace_target(
-                "primary",
-                WorkspaceTargetKind::PrimaryCheckout,
-                "/repo-b",
-                "Primary Checkout",
-            ),
-            workspace_target(
-                "worktree:task-b",
-                WorkspaceTargetKind::LinkedWorktree,
-                "/repo-b/worktrees/task-b",
-                "task-b",
-            ),
-        ];
+        with_temp_hunk_home("catalog-inputs-projects", |_| {
+            let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+            let chat_a = chats_root.join("chat-a");
+            std::fs::create_dir_all(&chat_a).expect("chat-a should exist");
+            let repo_a_targets = vec![
+                workspace_target(
+                    "primary",
+                    WorkspaceTargetKind::PrimaryCheckout,
+                    "/repo-a",
+                    "Primary Checkout",
+                ),
+                workspace_target(
+                    "worktree:task-a",
+                    WorkspaceTargetKind::LinkedWorktree,
+                    "/repo-a/worktrees/task-a",
+                    "task-a",
+                ),
+            ];
+            let repo_b_targets = vec![
+                workspace_target(
+                    "primary",
+                    WorkspaceTargetKind::PrimaryCheckout,
+                    "/repo-b",
+                    "Primary Checkout",
+                ),
+                workspace_target(
+                    "worktree:task-b",
+                    WorkspaceTargetKind::LinkedWorktree,
+                    "/repo-b/worktrees/task-b",
+                    "task-b",
+                ),
+            ];
 
-        let inputs = ai_workspace_catalog_inputs_from_target_sets(
-            &[repo_a_targets, repo_b_targets],
-            &[],
-            Some("/repo-b/worktrees/task-b"),
-        );
+            let inputs = ai_workspace_catalog_inputs_from_target_sets(
+                &[repo_a_targets, repo_b_targets],
+                &[],
+                Some("/repo-b/worktrees/task-b"),
+            );
 
-        assert_eq!(
-            inputs.known_workspace_keys,
-            BTreeSet::from([
-                chats_root.to_string_lossy().to_string(),
-                "/repo-a".to_string(),
-                "/repo-a/worktrees/task-a".to_string(),
-                "/repo-b".to_string(),
-                "/repo-b/worktrees/task-b".to_string(),
-            ])
-        );
-        assert_eq!(
-            inputs.workspace_roots,
-            vec![
-                PathBuf::from("/repo-a"),
-                PathBuf::from("/repo-a/worktrees/task-a"),
-                PathBuf::from("/repo-b"),
-                chats_root,
-            ]
-        );
+            assert_eq!(
+                inputs.known_workspace_keys,
+                BTreeSet::from([
+                    chats_root.to_string_lossy().to_string(),
+                    chat_a.to_string_lossy().to_string(),
+                    "/repo-a".to_string(),
+                    "/repo-a/worktrees/task-a".to_string(),
+                    "/repo-b".to_string(),
+                    "/repo-b/worktrees/task-b".to_string(),
+                ])
+            );
+            assert_eq!(
+                inputs.workspace_roots,
+                vec![
+                    PathBuf::from("/repo-a"),
+                    PathBuf::from("/repo-a/worktrees/task-a"),
+                    PathBuf::from("/repo-b"),
+                    chats_root,
+                    chat_a,
+                ]
+            );
+        });
     }
 
     #[test]
     fn workspace_catalog_inputs_keep_fallback_project_roots_for_projects_without_targets() {
-        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
-        let repo_a_targets = vec![workspace_target(
-            "primary",
-            WorkspaceTargetKind::PrimaryCheckout,
-            "/repo-a",
-            "Primary Checkout",
-        )];
+        with_temp_hunk_home("catalog-inputs-fallback", |_| {
+            let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
+            let chat_a = chats_root.join("chat-a");
+            std::fs::create_dir_all(&chat_a).expect("chat-a should exist");
+            let repo_a_targets = vec![workspace_target(
+                "primary",
+                WorkspaceTargetKind::PrimaryCheckout,
+                "/repo-a",
+                "Primary Checkout",
+            )];
 
-        let inputs = ai_workspace_catalog_inputs_from_target_sets(
-            &[repo_a_targets],
-            &[PathBuf::from("/repo-b")],
-            Some("/repo-a"),
-        );
+            let inputs = ai_workspace_catalog_inputs_from_target_sets(
+                &[repo_a_targets],
+                &[PathBuf::from("/repo-b")],
+                Some("/repo-a"),
+            );
 
-        assert_eq!(
-            inputs.known_workspace_keys,
-            BTreeSet::from([
-                chats_root.to_string_lossy().to_string(),
-                "/repo-a".to_string(),
-                "/repo-b".to_string(),
-            ])
-        );
-        assert_eq!(inputs.workspace_roots, vec![PathBuf::from("/repo-b"), chats_root]);
+            assert_eq!(
+                inputs.known_workspace_keys,
+                BTreeSet::from([
+                    chats_root.to_string_lossy().to_string(),
+                    chat_a.to_string_lossy().to_string(),
+                    "/repo-a".to_string(),
+                    "/repo-b".to_string(),
+                ])
+            );
+            assert_eq!(
+                inputs.workspace_roots,
+                vec![PathBuf::from("/repo-b"), chats_root, chat_a]
+            );
+        });
     }
 
     #[test]

--- a/crates/hunk-desktop/src/app/controller/ai/tests/workspace_state.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests/workspace_state.rs
@@ -888,6 +888,7 @@
 
     #[test]
     fn thread_catalog_workspace_roots_skip_visible_primary_checkout() {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
         let workspace_targets = vec![
             workspace_target(
                 "primary",
@@ -921,12 +922,14 @@
             vec![
                 PathBuf::from("/repo/worktrees/task-1"),
                 PathBuf::from("/repo/worktrees/task-2"),
+                chats_root,
             ]
         );
     }
 
     #[test]
     fn thread_catalog_workspace_roots_still_skip_visible_worktree() {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
         let workspace_targets = vec![
             workspace_target(
                 "primary",
@@ -957,12 +960,14 @@
             vec![
                 PathBuf::from("/repo"),
                 PathBuf::from("/repo/worktrees/task-2"),
+                chats_root,
             ]
         );
     }
 
     #[test]
     fn workspace_catalog_inputs_include_all_projects_and_skip_visible_workspace_root() {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
         let repo_a_targets = vec![
             workspace_target(
                 "primary",
@@ -1001,6 +1006,7 @@
         assert_eq!(
             inputs.known_workspace_keys,
             BTreeSet::from([
+                chats_root.to_string_lossy().to_string(),
                 "/repo-a".to_string(),
                 "/repo-a/worktrees/task-a".to_string(),
                 "/repo-b".to_string(),
@@ -1013,12 +1019,14 @@
                 PathBuf::from("/repo-a"),
                 PathBuf::from("/repo-a/worktrees/task-a"),
                 PathBuf::from("/repo-b"),
+                chats_root,
             ]
         );
     }
 
     #[test]
     fn workspace_catalog_inputs_keep_fallback_project_roots_for_projects_without_targets() {
+        let chats_root = resolve_ai_chats_root_path().expect("chats root should resolve");
         let repo_a_targets = vec![workspace_target(
             "primary",
             WorkspaceTargetKind::PrimaryCheckout,
@@ -1034,9 +1042,13 @@
 
         assert_eq!(
             inputs.known_workspace_keys,
-            BTreeSet::from(["/repo-a".to_string(), "/repo-b".to_string(),])
+            BTreeSet::from([
+                chats_root.to_string_lossy().to_string(),
+                "/repo-a".to_string(),
+                "/repo-b".to_string(),
+            ])
         );
-        assert_eq!(inputs.workspace_roots, vec![PathBuf::from("/repo-b")]);
+        assert_eq!(inputs.workspace_roots, vec![PathBuf::from("/repo-b"), chats_root]);
     }
 
     #[test]

--- a/crates/hunk-desktop/src/app/controller/ai/visible_threads_tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/visible_threads_tests.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod ai_visible_threads_tests {
     use std::collections::{BTreeMap, BTreeSet};
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use hunk_codex::state::AiState;
     use hunk_codex::state::ThreadLifecycleStatus;
@@ -10,7 +13,38 @@ mod ai_visible_threads_tests {
     use super::ai_visible_thread_sections;
     use super::merged_ai_visible_threads;
     use super::state_snapshot_workspace_key;
-    use std::path::PathBuf;
+
+    fn ai_test_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_temp_hunk_home<T>(test_name: &str, f: impl FnOnce(PathBuf) -> T) -> T {
+        let _guard = ai_test_env_lock()
+            .lock()
+            .expect("ai test env lock should be available");
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let temp_home = std::env::temp_dir().join(format!("hunk-ai-visible-{test_name}-{unique}"));
+        let previous = std::env::var_os(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR);
+        unsafe { std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, &temp_home) };
+        let _ = std::fs::remove_dir_all(&temp_home);
+        std::fs::create_dir_all(&temp_home).expect("temp hunk home should be created");
+
+        let result = f(temp_home.clone());
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR, value)
+            },
+            None => unsafe { std::env::remove_var(hunk_domain::paths::HUNK_HOME_DIR_ENV_VAR) },
+        }
+        let _ = std::fs::remove_dir_all(&temp_home);
+
+        result
+    }
 
     fn thread_summary(
         id: &str,
@@ -131,40 +165,45 @@ mod ai_visible_threads_tests {
 
     #[test]
     fn visible_thread_sections_follow_workspace_order_and_cap_per_project() {
-        let threads = vec![
-            thread_summary("repo-a-6", "/repo-a", 60, 60),
-            thread_summary("repo-a-5", "/repo-a", 50, 50),
-            thread_summary("repo-a-4", "/repo-a/worktrees/task-4", 40, 40),
-            thread_summary("repo-a-3", "/repo-a/worktrees/task-3", 30, 30),
-            thread_summary("repo-a-2", "/repo-a", 20, 20),
-            thread_summary("repo-a-1", "/repo-a", 10, 10),
-            thread_summary("repo-b-1", "/repo-b", 70, 70),
-        ];
+        with_temp_hunk_home("visible-thread-sections-order", |_| {
+            let threads = vec![
+                thread_summary("repo-a-6", "/repo-a", 60, 60),
+                thread_summary("repo-a-5", "/repo-a", 50, 50),
+                thread_summary("repo-a-4", "/repo-a/worktrees/task-4", 40, 40),
+                thread_summary("repo-a-3", "/repo-a/worktrees/task-3", 30, 30),
+                thread_summary("repo-a-2", "/repo-a", 20, 20),
+                thread_summary("repo-a-1", "/repo-a", 10, 10),
+                thread_summary("repo-b-1", "/repo-b", 70, 70),
+            ];
 
-        let sections = ai_visible_thread_sections(
-            threads,
-            &[PathBuf::from("/repo-a"), PathBuf::from("/repo-b")],
-            Some(std::path::Path::new("/repo-b")),
-            Some(std::path::Path::new("/repo-b")),
-            &BTreeSet::new(),
-        );
+            let sections = ai_visible_thread_sections(
+                threads,
+                &[PathBuf::from("/repo-a"), PathBuf::from("/repo-b")],
+                Some(std::path::Path::new("/repo-b")),
+                Some(std::path::Path::new("/repo-b")),
+                &BTreeSet::new(),
+            );
 
-        assert_eq!(sections.len(), 2);
-        assert_eq!(sections[0].project_root, PathBuf::from("/repo-a"));
-        assert_eq!(sections[0].total_thread_count, 6);
-        assert_eq!(sections[0].threads.len(), 5);
-        assert_eq!(sections[0].hidden_thread_count, 1);
-        let repo_a_thread_ids = sections[0]
-            .threads
-            .iter()
-            .map(|thread| thread.id.as_str())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            repo_a_thread_ids,
-            vec!["repo-a-6", "repo-a-5", "repo-a-4", "repo-a-3", "repo-a-2"]
-        );
+            assert_eq!(sections.len(), 3);
+            assert_eq!(sections[0].project_label, "Chats");
+            assert_eq!(sections[0].threads.len(), 0);
 
-        assert_eq!(sections[1].project_root, PathBuf::from("/repo-b"));
-        assert_eq!(sections[1].threads.len(), 1);
+            assert_eq!(sections[1].project_root, PathBuf::from("/repo-a"));
+            assert_eq!(sections[1].total_thread_count, 6);
+            assert_eq!(sections[1].threads.len(), 5);
+            assert_eq!(sections[1].hidden_thread_count, 1);
+            let repo_a_thread_ids = sections[1]
+                .threads
+                .iter()
+                .map(|thread| thread.id.as_str())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                repo_a_thread_ids,
+                vec!["repo-a-6", "repo-a-5", "repo-a-4", "repo-a-3", "repo-a-2"]
+            );
+
+            assert_eq!(sections[2].project_root, PathBuf::from("/repo-b"));
+            assert_eq!(sections[2].threads.len(), 1);
+        });
     }
 }

--- a/crates/hunk-desktop/src/app/controller/ai/visible_threads_tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/visible_threads_tests.rs
@@ -2,7 +2,6 @@
 mod ai_visible_threads_tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use hunk_codex::state::AiState;
@@ -14,15 +13,8 @@ mod ai_visible_threads_tests {
     use super::merged_ai_visible_threads;
     use super::state_snapshot_workspace_key;
 
-    fn ai_test_env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
     fn with_temp_hunk_home<T>(test_name: &str, f: impl FnOnce(PathBuf) -> T) -> T {
-        let _guard = ai_test_env_lock()
-            .lock()
-            .expect("ai test env lock should be available");
+        let _guard = crate::app::ai_paths::lock_hunk_home_test_env();
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time should be after epoch")

--- a/crates/hunk-desktop/src/app/controller/ai_composer_completion.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_composer_completion.rs
@@ -131,6 +131,7 @@ impl DiffViewer {
             sync_key.prompt.as_str(),
             sync_key.cursor,
             sync_key.session_settings_locked,
+            self.current_ai_workspace_kind() != AiWorkspaceKind::Chats,
         )
     }
 
@@ -549,18 +550,45 @@ impl DiffViewer {
 
         match command.item.kind {
             crate::app::ai_composer_commands::AiComposerSlashCommandKind::Code => {
+                if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+                    self.set_current_ai_composer_status(
+                        "Mode switching is unavailable in Chats.",
+                        cx,
+                    );
+                    self.sync_ai_composer_completion_menus(cx);
+                    cx.notify();
+                    return true;
+                }
                 self.ai_select_collaboration_mode_action(
                     hunk_domain::state::AiCollaborationModeSelection::Default,
                     cx,
                 );
             }
             crate::app::ai_composer_commands::AiComposerSlashCommandKind::Plan => {
+                if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+                    self.set_current_ai_composer_status(
+                        "Mode switching is unavailable in Chats.",
+                        cx,
+                    );
+                    self.sync_ai_composer_completion_menus(cx);
+                    cx.notify();
+                    return true;
+                }
                 self.ai_select_collaboration_mode_action(
                     hunk_domain::state::AiCollaborationModeSelection::Plan,
                     cx,
                 );
             }
             crate::app::ai_composer_commands::AiComposerSlashCommandKind::Review => {
+                if self.current_ai_workspace_kind() == AiWorkspaceKind::Chats {
+                    self.set_current_ai_composer_status(
+                        "Review mode is unavailable in Chats.",
+                        cx,
+                    );
+                    self.sync_ai_composer_completion_menus(cx);
+                    cx.notify();
+                    return true;
+                }
                 self.ai_select_review_mode_action(cx);
             }
             crate::app::ai_composer_commands::AiComposerSlashCommandKind::FastModeOn => {

--- a/crates/hunk-desktop/src/app/controller/ai_composer_completion.rs
+++ b/crates/hunk-desktop/src/app/controller/ai_composer_completion.rs
@@ -68,6 +68,15 @@ fn ai_select_previous_completion_item(
 }
 
 impl DiffViewer {
+    fn clear_ai_composer_file_completion_reload_state(&mut self, cx: &mut Context<Self>) {
+        self.ai_composer_file_completion_provider.clear();
+        self.ai_composer_file_completion_reload_task = Task::ready(());
+        self.ai_composer_file_completion_menu = None;
+        self.ai_composer_file_completion_dismissed_token = None;
+        self.ai_composer_file_completion_selected_ix = 0;
+        cx.notify();
+    }
+
     fn current_ai_composer_completion_context(
         &self,
         cx: &Context<Self>,
@@ -726,14 +735,14 @@ impl DiffViewer {
         cx: &mut Context<Self>,
     ) {
         let Some(workspace_root) = workspace_root else {
-            self.ai_composer_file_completion_provider.clear();
-            self.ai_composer_file_completion_reload_task = Task::ready(());
-            self.ai_composer_file_completion_menu = None;
-            self.ai_composer_file_completion_dismissed_token = None;
-            self.ai_composer_file_completion_selected_ix = 0;
-            cx.notify();
+            self.clear_ai_composer_file_completion_reload_state(cx);
             return;
         };
+
+        if self.ai_workspace_kind_for_root(workspace_root.as_path()) == AiWorkspaceKind::Chats {
+            self.clear_ai_composer_file_completion_reload_state(cx);
+            return;
+        }
 
         let provider = self.ai_composer_file_completion_provider.clone();
         let generation = provider.begin_reload(Some(workspace_root.clone()));

--- a/crates/hunk-desktop/src/app/render/ai.rs
+++ b/crates/hunk-desktop/src/app/render/ai.rs
@@ -32,7 +32,7 @@ impl DiffViewer {
         ai_view_state: Option<AiVisibleFrameState>,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        if self.repo_discovery_failed {
+        if self.repo_discovery_failed && self.current_ai_workspace_kind() != AiWorkspaceKind::Chats {
             return self.render_open_project_empty_state(cx);
         }
 
@@ -87,6 +87,7 @@ impl DiffViewer {
             selected_thread_id: selected_thread_id.clone(),
         };
         let timeline_state = AiTimelinePanelState {
+            workspace_kind: ai_view_state.workspace_kind,
             active_branch: ai_view_state.active_branch.clone(),
             workspace_label: ai_view_state.active_workspace_label.clone(),
             show_worktree_base_branch_picker: ai_view_state.show_worktree_base_branch_picker,
@@ -125,6 +126,7 @@ impl DiffViewer {
             model_supports_image_inputs: ai_view_state.model_supports_image_inputs,
             review_mode_active: self.ai_review_mode_active,
             usage_popover_open: self.ai_usage_popover_open,
+            show_mode_badge: ai_view_state.workspace_kind.shows_mode_badge(),
             current_mode_label: crate::app::ai_composer_commands::ai_composer_mode_label(
                 self.ai_review_mode_active,
                 self.ai_selected_collaboration_mode,
@@ -135,6 +137,7 @@ impl DiffViewer {
                 hunk_domain::state::AiServiceTierSelection::Fast
             ),
             selected_thread_mode_for_picker,
+            show_thread_mode_picker: ai_view_state.workspace_kind.shows_thread_mode_picker(),
             thread_mode_picker_editable,
             session_controls_read_only: ai_view_state.composer_interrupt_available,
             selected_thread_context_usage: ai_view_state.selected_thread_context_usage.clone(),
@@ -174,7 +177,7 @@ impl DiffViewer {
             self.render_ai_composer_panel(view.clone(), &composer_state, is_dark, cx);
         let terminal_panel = self
             .render_workspace_terminal_panel(view.clone(), &terminal_state, is_dark, cx)
-            .filter(|_| terminal_state.open);
+            .filter(|_| ai_view_state.workspace_kind.shows_terminal() && terminal_state.open);
         let workspace = self.render_ai_workspace_content(
             view,
             AiWorkspaceContentSections {

--- a/crates/hunk-desktop/src/app/render/ai_composer.rs
+++ b/crates/hunk-desktop/src/app/render/ai_composer.rs
@@ -7,9 +7,11 @@ struct AiComposerPanelState {
     model_supports_image_inputs: bool,
     review_mode_active: bool,
     usage_popover_open: bool,
+    show_mode_badge: bool,
     current_mode_label: String,
     fast_mode_enabled: bool,
     selected_thread_mode_for_picker: AiNewThreadStartMode,
+    show_thread_mode_picker: bool,
     thread_mode_picker_editable: bool,
     session_controls_read_only: bool,
     selected_thread_context_usage: Option<hunk_codex::state::ThreadTokenUsageSummary>,
@@ -232,17 +234,20 @@ impl DiffViewer {
                         self,
                         view.clone(),
                         state.selected_thread_mode_for_picker,
+                        state.show_thread_mode_picker,
                         state.thread_mode_picker_editable,
                         state.session_controls_read_only,
                         cx,
                     ))
-                    .child(ai_render_composer_status_chip(
-                        ai_composer_mode_badge_label(state.current_mode_label.as_str()).as_str(),
-                        ai_composer_mode_badge_icon(state.current_mode_label.as_str()),
-                        completion_colors.row_selected_border,
-                        completion_colors.accent_soft_background,
-                        cx.theme().foreground,
-                    ))
+                    .when(state.show_mode_badge, |this| {
+                        this.child(ai_render_composer_status_chip(
+                            ai_composer_mode_badge_label(state.current_mode_label.as_str()).as_str(),
+                            ai_composer_mode_badge_icon(state.current_mode_label.as_str()),
+                            completion_colors.row_selected_border,
+                            completion_colors.accent_soft_background,
+                            cx.theme().foreground,
+                        ))
+                    })
                     .when(state.fast_mode_enabled, |this| {
                         this.child(ai_render_composer_status_chip(
                             "Fast",

--- a/crates/hunk-desktop/src/app/render/ai_helpers/session_panels.rs
+++ b/crates/hunk-desktop/src/app/render/ai_helpers/session_panels.rs
@@ -62,6 +62,7 @@ struct AiSessionControlsPanelView<'a> {
     selected_model: Option<&'a str>,
     selected_effort: Option<&'a str>,
     selected_thread_mode: AiNewThreadStartMode,
+    show_thread_mode_picker: bool,
     thread_mode_editable: bool,
     read_only: bool,
     mad_max_mode: bool,
@@ -71,6 +72,7 @@ fn render_ai_session_controls_panel_for_view(
     this: &DiffViewer,
     view: Entity<DiffViewer>,
     selected_thread_mode: AiNewThreadStartMode,
+    show_thread_mode_picker: bool,
     thread_mode_editable: bool,
     read_only: bool,
     cx: &mut Context<DiffViewer>,
@@ -81,6 +83,7 @@ fn render_ai_session_controls_panel_for_view(
             selected_model: this.ai_selected_model.as_deref(),
             selected_effort: this.ai_selected_effort.as_deref(),
             selected_thread_mode,
+            show_thread_mode_picker,
             thread_mode_editable,
             read_only,
             mad_max_mode: this.ai_mad_max_mode,
@@ -285,55 +288,57 @@ fn render_ai_session_controls_panel(
                     menu
                 })
         })
-        .child({
-            let view = view.clone();
-            let selected_mode = panel.selected_thread_mode;
-            Button::new("ai-session-thread-mode-dropdown")
-                .compact()
-                .ghost()
-                .rounded(px(999.0))
-                .with_size(gpui_component::Size::Small)
-                .px_1()
-                .dropdown_caret(true)
-                .label(thread_mode_label)
-                .disabled(panel.read_only || !panel.thread_mode_editable)
-                .tooltip(if panel.read_only {
-                    controls_locked_tooltip
-                } else {
-                    "Thread mode can only be changed before the first prompt is sent."
-                })
-                .dropdown_menu(move |menu, _, _| {
-                    menu.item(
-                        PopupMenuItem::new("Local")
-                            .checked(matches!(selected_mode, AiNewThreadStartMode::Local))
-                            .on_click({
-                                let view = view.clone();
-                                move |_, _, cx| {
-                                    view.update(cx, |this, cx| {
-                                        this.ai_select_new_thread_start_mode_action(
-                                            AiNewThreadStartMode::Local,
-                                            cx,
-                                        );
-                                    });
-                                }
-                            }),
-                    )
-                    .item(
-                        PopupMenuItem::new("Worktree")
-                            .checked(matches!(selected_mode, AiNewThreadStartMode::Worktree))
-                            .on_click({
-                                let view = view.clone();
-                                move |_, _, cx| {
-                                    view.update(cx, |this, cx| {
-                                        this.ai_select_new_thread_start_mode_action(
-                                            AiNewThreadStartMode::Worktree,
-                                            cx,
-                                        );
-                                    });
-                                }
-                            }),
-                    )
-                })
+        .when(panel.show_thread_mode_picker, |this| {
+            this.child({
+                let view = view.clone();
+                let selected_mode = panel.selected_thread_mode;
+                Button::new("ai-session-thread-mode-dropdown")
+                    .compact()
+                    .ghost()
+                    .rounded(px(999.0))
+                    .with_size(gpui_component::Size::Small)
+                    .px_1()
+                    .dropdown_caret(true)
+                    .label(thread_mode_label)
+                    .disabled(panel.read_only || !panel.thread_mode_editable)
+                    .tooltip(if panel.read_only {
+                        controls_locked_tooltip
+                    } else {
+                        "Thread mode can only be changed before the first prompt is sent."
+                    })
+                    .dropdown_menu(move |menu, _, _| {
+                        menu.item(
+                            PopupMenuItem::new("Local")
+                                .checked(matches!(selected_mode, AiNewThreadStartMode::Local))
+                                .on_click({
+                                    let view = view.clone();
+                                    move |_, _, cx| {
+                                        view.update(cx, |this, cx| {
+                                            this.ai_select_new_thread_start_mode_action(
+                                                AiNewThreadStartMode::Local,
+                                                cx,
+                                            );
+                                        });
+                                    }
+                                }),
+                        )
+                        .item(
+                            PopupMenuItem::new("Worktree")
+                                .checked(matches!(selected_mode, AiNewThreadStartMode::Worktree))
+                                .on_click({
+                                    let view = view.clone();
+                                    move |_, _, cx| {
+                                        view.update(cx, |this, cx| {
+                                            this.ai_select_new_thread_start_mode_action(
+                                                AiNewThreadStartMode::Worktree,
+                                                cx,
+                                            );
+                                        });
+                                    }
+                                }),
+                        )
+                    })
+            })
         })
         .into_any_element()
 }

--- a/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
+++ b/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
@@ -464,12 +464,10 @@ impl DiffViewer {
                 } else {
                     format!("New Thread  {shortcut}")
                 }
+            } else if workspace_kind == AiWorkspaceKind::Chats {
+                "New Chat".to_string()
             } else {
-                if workspace_kind == AiWorkspaceKind::Chats {
-                    "New Chat".to_string()
-                } else {
-                    "New Thread".to_string()
-                }
+                "New Thread".to_string()
             };
         let new_worktree_label =
             if let Some(shortcut) = ai_new_thread_shortcut_label(AiNewThreadStartMode::Worktree) {
@@ -526,9 +524,9 @@ impl DiffViewer {
                             .outline()
                             .rounded(px(999.0))
                             .with_size(gpui_component::Size::Small)
-                            .px_2()
+                            .px_1()
                             .icon(Icon::new(HunkIconName::NotebookPen).size(px(14.0)))
-                            .label(new_thread_label)
+                            .tooltip(new_thread_label.clone())
                             .on_click(move |_, window, cx| {
                                 view.update(cx, |this, cx| {
                                     this.ai_start_chat_thread_draft(window, cx);

--- a/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
+++ b/crates/hunk-desktop/src/app/render/ai_workspace_sections.rs
@@ -6,6 +6,7 @@ struct AiThreadSidebarState {
 }
 
 struct AiTimelinePanelState {
+    workspace_kind: AiWorkspaceKind,
     active_branch: String,
     workspace_label: String,
     show_worktree_base_branch_picker: bool,
@@ -379,12 +380,14 @@ impl DiffViewer {
         let render_started_at = Instant::now();
         let (element, row_kind) = match row.kind {
             AiThreadSidebarRowKind::ProjectHeader {
+                workspace_kind,
                 project_root,
                 project_label,
                 total_thread_count,
             } => (
                 self.render_ai_thread_project_header_row(
                     view,
+                    workspace_kind,
                     project_root,
                     project_label,
                     total_thread_count,
@@ -408,17 +411,22 @@ impl DiffViewer {
                     AiPerfSidebarRowKind::Thread,
                 )
             }
-            AiThreadSidebarRowKind::EmptyProject { project_root } => (
-                self.render_ai_thread_project_empty_row(project_root, is_dark, cx),
+            AiThreadSidebarRowKind::EmptyProject {
+                workspace_kind,
+                project_root,
+            } => (
+                self.render_ai_thread_project_empty_row(workspace_kind, project_root, is_dark, cx),
                 AiPerfSidebarRowKind::EmptyProject,
             ),
             AiThreadSidebarRowKind::ProjectFooter {
+                workspace_kind,
                 project_root,
                 hidden_thread_count,
                 expanded,
             } => (
                 self.render_ai_thread_project_footer_row(
                     view,
+                    workspace_kind,
                     project_root,
                     hidden_thread_count,
                     expanded,
@@ -435,6 +443,7 @@ impl DiffViewer {
     fn render_ai_thread_project_header_row(
         &self,
         view: Entity<Self>,
+        workspace_kind: AiWorkspaceKind,
         project_root: PathBuf,
         project_label: String,
         total_thread_count: usize,
@@ -450,9 +459,17 @@ impl DiffViewer {
         };
         let new_thread_label =
             if let Some(shortcut) = ai_new_thread_shortcut_label(AiNewThreadStartMode::Local) {
-                format!("New Thread  {shortcut}")
+                if workspace_kind == AiWorkspaceKind::Chats {
+                    format!("New Chat  {shortcut}")
+                } else {
+                    format!("New Thread  {shortcut}")
+                }
             } else {
-                "New Thread".to_string()
+                if workspace_kind == AiWorkspaceKind::Chats {
+                    "New Chat".to_string()
+                } else {
+                    "New Thread".to_string()
+                }
             };
         let new_worktree_label =
             if let Some(shortcut) = ai_new_thread_shortcut_label(AiNewThreadStartMode::Worktree) {
@@ -502,85 +519,108 @@ impl DiffViewer {
                 h_flex()
                     .items_center()
                     .gap_2()
-                    .child({
-                        let new_button_view = view.clone();
-                        let new_button_project_root = project_root.clone();
+                    .child(if workspace_kind == AiWorkspaceKind::Chats {
+                        let view = view.clone();
                         Button::new(format!("ai-thread-project-actions-{project_key}"))
                             .compact()
                             .outline()
                             .rounded(px(999.0))
                             .with_size(gpui_component::Size::Small)
-                            .px_1()
-                            .tooltip("New thread")
+                            .px_2()
+                            .icon(Icon::new(HunkIconName::NotebookPen).size(px(14.0)))
+                            .label(new_thread_label)
+                            .on_click(move |_, window, cx| {
+                                view.update(cx, |this, cx| {
+                                    this.ai_start_chat_thread_draft(window, cx);
+                                });
+                            })
+                            .into_any_element()
+                    } else {
+                        let new_button_view = view.clone();
+                        let new_button_project_root = project_root.clone();
+                        h_flex()
+                            .items_center()
+                            .gap_2()
                             .child(
-                                h_flex()
-                                    .items_center()
-                                    .gap_1()
-                                    .child(Icon::new(HunkIconName::NotebookPen).size(px(14.0)))
-                                    .child(Icon::new(IconName::ChevronDown).size(px(12.0))),
+                                Button::new(format!("ai-thread-project-actions-{project_key}"))
+                                    .compact()
+                                    .outline()
+                                    .rounded(px(999.0))
+                                    .with_size(gpui_component::Size::Small)
+                                    .px_1()
+                                    .tooltip("New thread")
+                                    .child(
+                                        h_flex()
+                                            .items_center()
+                                            .gap_1()
+                                            .child(Icon::new(HunkIconName::NotebookPen).size(px(14.0)))
+                                            .child(Icon::new(IconName::ChevronDown).size(px(12.0))),
+                                    )
+                                    .dropdown_menu(move |menu, _, _| {
+                                        menu.item(PopupMenuItem::new(new_thread_label.clone()).on_click({
+                                            let view = new_button_view.clone();
+                                            let project_root = new_button_project_root.clone();
+                                            move |_, window, cx| {
+                                                view.update(cx, |this, cx| {
+                                                    this.ai_start_thread_draft_for_project_root(
+                                                        project_root.clone(),
+                                                        AiNewThreadStartMode::Local,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                });
+                                            }
+                                        }))
+                                        .item(
+                                            PopupMenuItem::new(new_worktree_label.clone()).on_click({
+                                                let view = new_button_view.clone();
+                                                let project_root = new_button_project_root.clone();
+                                                move |_, window, cx| {
+                                                    view.update(cx, |this, cx| {
+                                                        this.ai_start_thread_draft_for_project_root(
+                                                            project_root.clone(),
+                                                            AiNewThreadStartMode::Worktree,
+                                                            window,
+                                                            cx,
+                                                        );
+                                                    });
+                                                }
+                                            }),
+                                        )
+                                    }),
                             )
-                            .dropdown_menu(move |menu, _, _| {
-                                menu.item(PopupMenuItem::new(new_thread_label.clone()).on_click({
-                                    let view = new_button_view.clone();
-                                    let project_root = new_button_project_root.clone();
-                                    move |_, window, cx| {
-                                        view.update(cx, |this, cx| {
-                                            this.ai_start_thread_draft_for_project_root(
-                                                project_root.clone(),
-                                                AiNewThreadStartMode::Local,
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                    }
-                                }))
-                                .item(
-                                    PopupMenuItem::new(new_worktree_label.clone()).on_click({
-                                        let view = new_button_view.clone();
-                                        let project_root = new_button_project_root.clone();
+                            .child(
+                                Button::new(format!("ai-thread-project-remove-{project_key}"))
+                                    .compact()
+                                    .danger()
+                                    .rounded(px(999.0))
+                                    .with_size(gpui_component::Size::Small)
+                                    .px_1()
+                                    .icon(Icon::new(IconName::Delete).size(px(14.0)))
+                                    .tooltip("Remove project")
+                                    .on_click({
+                                        let view = view.clone();
+                                        let project_root = project_root.clone();
                                         move |_, window, cx| {
                                             view.update(cx, |this, cx| {
-                                                this.ai_start_thread_draft_for_project_root(
+                                                this.confirm_remove_workspace_project_action(
                                                     project_root.clone(),
-                                                    AiNewThreadStartMode::Worktree,
                                                     window,
                                                     cx,
                                                 );
                                             });
                                         }
                                     }),
-                                )
-                            })
-                    })
-                    .child(
-                        Button::new(format!("ai-thread-project-remove-{project_key}"))
-                            .compact()
-                            .danger()
-                            .rounded(px(999.0))
-                            .with_size(gpui_component::Size::Small)
-                            .px_1()
-                            .icon(Icon::new(IconName::Delete).size(px(14.0)))
-                            .tooltip("Remove project")
-                            .on_click({
-                                let view = view.clone();
-                                let project_root = project_root.clone();
-                                move |_, window, cx| {
-                                    view.update(cx, |this, cx| {
-                                        this.confirm_remove_workspace_project_action(
-                                            project_root.clone(),
-                                            window,
-                                            cx,
-                                        );
-                                    });
-                                }
-                            }),
-                    ),
+                            )
+                            .into_any_element()
+                    }),
             )
             .into_any_element()
     }
 
     fn render_ai_thread_project_empty_row(
         &self,
+        workspace_kind: AiWorkspaceKind,
         project_root: PathBuf,
         is_dark: bool,
         cx: &mut Context<Self>,
@@ -598,13 +638,18 @@ impl DiffViewer {
                 0.84,
                 0.94,
             ))
-            .child("No threads")
+            .child(if workspace_kind == AiWorkspaceKind::Chats {
+                "No chats"
+            } else {
+                "No threads"
+            })
             .into_any_element()
     }
 
     fn render_ai_thread_project_footer_row(
         &self,
         view: Entity<Self>,
+        _: AiWorkspaceKind,
         project_root: PathBuf,
         hidden_thread_count: usize,
         expanded: bool,
@@ -816,12 +861,280 @@ impl DiffViewer {
         is_dark: bool,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        let selected_thread_project_label = state
-            .selected_thread_id
-            .as_deref()
+        let show_repo_actions = state.workspace_kind.shows_repo_actions();
+        let selected_thread_project_label = show_repo_actions
+            .then_some(state.selected_thread_id.as_deref())
+            .flatten()
             .and_then(|thread_id| self.ai_visible_project_root_with_context(Some(thread_id), None))
             .as_deref()
             .map(crate::app::project_picker::project_display_name);
+
+        let workspace_actions = if show_repo_actions {
+            h_flex()
+                .flex_none()
+                .items_center()
+                .gap_2()
+                .child(
+                    div()
+                        .text_xs()
+                        .font_family(cx.theme().mono_font_family.clone())
+                        .text_color(cx.theme().muted_foreground)
+                        .child(format!("Target: {}", state.workspace_label)),
+                )
+                .when(state.show_worktree_base_branch_picker, |this| {
+                    this.child(
+                        h_flex()
+                            .items_center()
+                            .gap_1p5()
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .font_semibold()
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child("Base Branch"),
+                            )
+                            .child(
+                                render_hunk_picker(
+                                    &self.ai_worktree_base_branch_picker_state,
+                                    HunkPickerConfig::new(
+                                        "ai-worktree-base-branch-picker",
+                                        state.selected_worktree_base_branch.clone(),
+                                    )
+                                    .with_size(gpui_component::Size::Small)
+                                    .rounded(px(8.0))
+                                    .width(px(220.0))
+                                    .background(hunk_opacity(
+                                        cx.theme().background,
+                                        is_dark,
+                                        0.82,
+                                        0.98,
+                                    ))
+                                    .border_color(cx.theme().border)
+                                    .disabled(self.git_controls_busy() || self.branches.is_empty())
+                                    .empty(
+                                        h_flex()
+                                            .h(px(72.0))
+                                            .justify_center()
+                                            .text_sm()
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child("No branches available."),
+                                    ),
+                                    cx,
+                                ),
+                            ),
+                    )
+                })
+                .child(
+                    div()
+                        .text_xs()
+                        .font_family(cx.theme().mono_font_family.clone())
+                        .text_color(cx.theme().muted_foreground)
+                        .child(format!("Branch: {}", state.active_branch)),
+                )
+                .child({
+                    let view = view.clone();
+                    let diff_button_enabled = self.ai_can_open_inline_review_for_current_thread();
+                    let diff_button_active = self.ai_inline_review_is_open()
+                        && self.current_ai_inline_review_mode()
+                            == AiInlineReviewMode::WorkingTree;
+                    Button::new("ai-open-working-tree-diff")
+                        .compact()
+                        .outline()
+                        .with_size(gpui_component::Size::Small)
+                        .rounded(px(8.0))
+                        .icon(Icon::new(HunkIconName::FileDiff).size(px(14.0)))
+                        .tooltip(if diff_button_enabled {
+                            if diff_button_active {
+                                "Close working tree diff (Cmd/Ctrl+D)"
+                            } else {
+                                "Open working tree diff (Cmd/Ctrl+D)"
+                            }
+                        } else {
+                            "No AI diff is available for the current thread yet"
+                        })
+                        .disabled(!diff_button_enabled)
+                        .on_click(move |_, _, cx| {
+                            view.update(cx, |this, cx| {
+                                this.ai_toggle_inline_review_for_current_thread_in_mode(
+                                    AiInlineReviewMode::WorkingTree,
+                                    cx,
+                                );
+                            });
+                        })
+                })
+                .child({
+                    let view_for_primary = view.clone();
+                    let view_for_menu = view.clone();
+                    let available_project_open_targets = self.available_project_open_targets.clone();
+                    let preferred_project_open_target = self.preferred_project_open_target();
+                    let primary_project_open_target = preferred_project_open_target
+                        .or_else(|| available_project_open_targets.first().copied());
+                    let project_open_tooltip = self.ai_project_open_tooltip();
+                    let project_open_disabled =
+                        self.ai_project_open_path().is_none() || primary_project_open_target.is_none();
+                    DropdownButton::new("ai-open-project-dropdown")
+                        .button(
+                            Button::new("ai-open-project")
+                                .compact()
+                                .outline()
+                                .with_size(gpui_component::Size::Small)
+                                .rounded(px(8.0))
+                                .when_some(primary_project_open_target, |this, target| {
+                                    this.icon(ai_project_open_target_icon(target))
+                                })
+                                .label("Open")
+                                .tooltip(project_open_tooltip)
+                                .disabled(project_open_disabled)
+                                .on_click(move |_, _, cx| {
+                                    view_for_primary.update(cx, |this, cx| {
+                                        this.open_ai_workspace_in_preferred_project_target(cx);
+                                    });
+                                }),
+                        )
+                        .compact()
+                        .outline()
+                        .with_size(gpui_component::Size::Small)
+                        .rounded(px(8.0))
+                        .disabled(project_open_disabled)
+                        .dropdown_menu(move |menu, _, _| {
+                            if available_project_open_targets.is_empty() {
+                                return menu.item(
+                                    PopupMenuItem::new("No supported editors or file managers found")
+                                        .disabled(true),
+                                );
+                            }
+
+                            available_project_open_targets.iter().copied().fold(
+                                menu,
+                                |menu, target| {
+                                    let view = view_for_menu.clone();
+                                    menu.item(
+                                        PopupMenuItem::new(target.display_label())
+                                            .icon(ai_project_open_target_icon(target))
+                                            .on_click(move |_, _, cx| {
+                                                view.update(cx, |this, cx| {
+                                                    this.open_ai_workspace_in_project_target(
+                                                        target, cx,
+                                                    );
+                                                });
+                                            }),
+                                    )
+                                },
+                            )
+                        })
+                        .into_any_element()
+                })
+                .child({
+                    let view = view.clone();
+                    let push_label = format!("Commit and Push to {}", state.active_branch);
+                    let create_branch_label = "Create Branch and Push".to_string();
+                    let publish_tooltip =
+                        state.ai_publish_blocker.clone().unwrap_or_else(|| {
+                            match state.selected_thread_start_mode {
+                                Some(AiNewThreadStartMode::Local) => {
+                                    "Commit and push the current branch, create a fresh branch and push it, or open PR/MR for the current work. If the current branch is the default branch, Hunk creates a new branch automatically.".to_string()
+                                }
+                                Some(AiNewThreadStartMode::Worktree) => {
+                                    "Commit and push this worktree branch, create a fresh branch and push it, or open PR/MR for the current work.".to_string()
+                                }
+                                None => "Commit and push this branch, create a fresh branch and push it, or open PR/MR for it.".to_string(),
+                            }
+                        });
+                    Button::new("ai-publish-thread")
+                        .compact()
+                        .outline()
+                        .with_size(gpui_component::Size::Small)
+                        .rounded(px(8.0))
+                        .loading(
+                            state.ai_commit_and_push_loading
+                                || state.ai_create_branch_and_push_loading
+                                || state.ai_open_pr_loading,
+                        )
+                        .dropdown_caret(true)
+                        .label("Publish")
+                        .tooltip(publish_tooltip)
+                        .disabled(state.ai_publish_disabled || state.ai_open_pr_disabled)
+                        .dropdown_menu(move |menu, _, _| {
+                            menu.item(PopupMenuItem::new(push_label.clone()).on_click({
+                                let view = view.clone();
+                                move |_, _, cx| {
+                                    view.update(cx, |this, cx| {
+                                        this.ai_commit_and_push_for_current_thread(cx);
+                                    });
+                                }
+                            }))
+                            .item(PopupMenuItem::new(create_branch_label.clone()).on_click({
+                                let view = view.clone();
+                                move |_, window, cx| {
+                                    view.update(cx, |this, cx| {
+                                        this.ai_create_branch_and_push_for_current_thread(
+                                            window, cx,
+                                        );
+                                    });
+                                }
+                            }))
+                            .item(PopupMenuItem::separator())
+                            .item(PopupMenuItem::new("Open PR").on_click({
+                                let view = view.clone();
+                                move |_, window, cx| {
+                                    view.update(cx, |this, cx| {
+                                        this.ai_open_pr_for_current_thread(window, cx);
+                                    });
+                                }
+                            }))
+                        })
+                        .into_any_element()
+                })
+                .when_some(state.ai_managed_worktree_target.clone(), |this, target| {
+                    let view = view.clone();
+                    let tooltip = state.ai_delete_worktree_blocker.clone().unwrap_or_else(|| {
+                        format!(
+                            "Delete managed worktree '{}' after the thread is done.",
+                            target.name
+                        )
+                    });
+                    this.child(
+                        Button::new("ai-delete-worktree")
+                            .compact()
+                            .danger()
+                            .with_size(gpui_component::Size::Small)
+                            .rounded(px(8.0))
+                            .icon(Icon::new(IconName::Delete).size(px(14.0)))
+                            .label("Delete Worktree")
+                            .tooltip(tooltip)
+                            .loading(state.ai_delete_worktree_loading)
+                            .disabled(state.ai_delete_worktree_blocker.is_some())
+                            .on_click(move |_, window, cx| {
+                                view.update(cx, |this, cx| {
+                                    this.ai_confirm_delete_current_worktree_action(window, cx);
+                                });
+                            }),
+                    )
+                })
+                .when(self.ai_mad_max_mode, |this| {
+                    this.child(
+                        div()
+                            .text_xs()
+                            .text_color(cx.theme().danger)
+                            .child("Full access enabled"),
+                    )
+                })
+                .into_any_element()
+        } else {
+            h_flex()
+                .flex_none()
+                .items_center()
+                .gap_2()
+                .child(
+                    div()
+                        .text_xs()
+                        .font_family(cx.theme().mono_font_family.clone())
+                        .text_color(cx.theme().muted_foreground)
+                        .child(state.workspace_label.clone()),
+                )
+                .into_any_element()
+        };
+
         h_flex()
             .w_full()
             .items_center()
@@ -848,271 +1161,7 @@ impl DiffViewer {
                         this.child(ai_render_thread_start_mode_chip(start_mode, is_dark, cx))
                     }),
             )
-            .child(
-                h_flex()
-                    .flex_1()
-                    .justify_end()
-                    .child(
-                        h_flex()
-                            .flex_none()
-                            .items_center()
-                            .gap_2()
-                            .child(
-                                div()
-                                    .text_xs()
-                                    .font_family(cx.theme().mono_font_family.clone())
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child(format!("Target: {}", state.workspace_label)),
-                            )
-                            .when(state.show_worktree_base_branch_picker, |this| {
-                                this.child(
-                                    h_flex()
-                                        .items_center()
-                                        .gap_1p5()
-                                        .child(
-                                            div()
-                                                .text_xs()
-                                                .font_semibold()
-                                                .text_color(cx.theme().muted_foreground)
-                                                .child("Base Branch"),
-                                        )
-                                        .child(
-                                            render_hunk_picker(
-                                                &self.ai_worktree_base_branch_picker_state,
-                                                HunkPickerConfig::new(
-                                                    "ai-worktree-base-branch-picker",
-                                                    state.selected_worktree_base_branch.clone(),
-                                                )
-                                                .with_size(gpui_component::Size::Small)
-                                                .rounded(px(8.0))
-                                                .width(px(220.0))
-                                                .background(hunk_opacity(
-                                                    cx.theme().background,
-                                                    is_dark,
-                                                    0.82,
-                                                    0.98,
-                                                ))
-                                                .border_color(cx.theme().border)
-                                                .disabled(
-                                                    self.git_controls_busy()
-                                                        || self.branches.is_empty(),
-                                                )
-                                                .empty(
-                                                    h_flex()
-                                                        .h(px(72.0))
-                                                        .justify_center()
-                                                        .text_sm()
-                                                        .text_color(cx.theme().muted_foreground)
-                                                        .child("No branches available."),
-                                                ),
-                                                cx,
-                                            ),
-                                        ),
-                                )
-                            })
-                            .child(
-                                div()
-                                    .text_xs()
-                                    .font_family(cx.theme().mono_font_family.clone())
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child(format!("Branch: {}", state.active_branch)),
-                            )
-                            .child({
-                        let view = view.clone();
-                        let diff_button_enabled = self.ai_can_open_inline_review_for_current_thread();
-                        let diff_button_active =
-                            self.ai_inline_review_is_open()
-                                && self.current_ai_inline_review_mode()
-                                    == AiInlineReviewMode::WorkingTree;
-                        Button::new("ai-open-working-tree-diff")
-                            .compact()
-                            .outline()
-                            .with_size(gpui_component::Size::Small)
-                            .rounded(px(8.0))
-                            .icon(Icon::new(HunkIconName::FileDiff).size(px(14.0)))
-                            .tooltip(if diff_button_enabled {
-                                if diff_button_active {
-                                    "Close working tree diff (Cmd/Ctrl+D)"
-                                } else {
-                                    "Open working tree diff (Cmd/Ctrl+D)"
-                                }
-                            } else {
-                                "No AI diff is available for the current thread yet"
-                            })
-                            .disabled(!diff_button_enabled)
-                            .on_click(move |_, _, cx| {
-                                view.update(cx, |this, cx| {
-                                    this.ai_toggle_inline_review_for_current_thread_in_mode(
-                                        AiInlineReviewMode::WorkingTree,
-                                        cx,
-                                    );
-                                });
-                            })
-                    })
-                            .child({
-                        let view_for_primary = view.clone();
-                        let view_for_menu = view.clone();
-                        let available_project_open_targets =
-                            self.available_project_open_targets.clone();
-                        let preferred_project_open_target = self.preferred_project_open_target();
-                        let primary_project_open_target = preferred_project_open_target
-                            .or_else(|| available_project_open_targets.first().copied());
-                        let project_open_tooltip = self.ai_project_open_tooltip();
-                        let project_open_disabled = self.ai_project_open_path().is_none()
-                            || primary_project_open_target.is_none();
-                        DropdownButton::new("ai-open-project-dropdown")
-                            .button(
-                                Button::new("ai-open-project")
-                                    .compact()
-                                    .outline()
-                                    .with_size(gpui_component::Size::Small)
-                                    .rounded(px(8.0))
-                                    .when_some(primary_project_open_target, |this, target| {
-                                        this.icon(ai_project_open_target_icon(target))
-                                    })
-                                    .label("Open")
-                                    .tooltip(project_open_tooltip)
-                                    .disabled(project_open_disabled)
-                                    .on_click(move |_, _, cx| {
-                                        view_for_primary.update(cx, |this, cx| {
-                                            this.open_ai_workspace_in_preferred_project_target(cx);
-                                        });
-                                    }),
-                            )
-                            .compact()
-                            .outline()
-                            .with_size(gpui_component::Size::Small)
-                            .rounded(px(8.0))
-                            .disabled(project_open_disabled)
-                            .dropdown_menu(move |menu, _, _| {
-                                if available_project_open_targets.is_empty() {
-                                    return menu.item(
-                                        PopupMenuItem::new(
-                                            "No supported editors or file managers found",
-                                        )
-                                        .disabled(true),
-                                    );
-                                }
-
-                                available_project_open_targets.iter().copied().fold(
-                                    menu,
-                                    |menu, target| {
-                                        let view = view_for_menu.clone();
-                                        menu.item(
-                                            PopupMenuItem::new(target.display_label())
-                                                .icon(ai_project_open_target_icon(target))
-                                                .on_click(move |_, _, cx| {
-                                                    view.update(cx, |this, cx| {
-                                                        this.open_ai_workspace_in_project_target(
-                                                            target, cx,
-                                                        );
-                                                    });
-                                                }),
-                                        )
-                                    },
-                                )
-                            })
-                            .into_any_element()
-                    })
-                    .child({
-                        let view = view.clone();
-                        let push_label = format!("Commit and Push to {}", state.active_branch);
-                        let create_branch_label = "Create Branch and Push".to_string();
-                        let publish_tooltip = state.ai_publish_blocker.clone().unwrap_or_else(|| {
-                            match state.selected_thread_start_mode {
-                                Some(AiNewThreadStartMode::Local) => {
-                                    "Commit and push the current branch, create a fresh branch and push it, or open PR/MR for the current work. If the current branch is the default branch, Hunk creates a new branch automatically.".to_string()
-                                }
-                                Some(AiNewThreadStartMode::Worktree) => {
-                                    "Commit and push this worktree branch, create a fresh branch and push it, or open PR/MR for the current work.".to_string()
-                                }
-                                None => "Commit and push this branch, create a fresh branch and push it, or open PR/MR for it.".to_string(),
-                            }
-                        });
-                        Button::new("ai-publish-thread")
-                            .compact()
-                            .outline()
-                            .with_size(gpui_component::Size::Small)
-                            .rounded(px(8.0))
-                            .loading(
-                                state.ai_commit_and_push_loading
-                                    || state.ai_create_branch_and_push_loading
-                                    || state.ai_open_pr_loading,
-                            )
-                            .dropdown_caret(true)
-                            .label("Publish")
-                            .tooltip(publish_tooltip)
-                            .disabled(state.ai_publish_disabled || state.ai_open_pr_disabled)
-                            .dropdown_menu(move |menu, _, _| {
-                                menu.item(
-                                    PopupMenuItem::new(push_label.clone()).on_click({
-                                        let view = view.clone();
-                                        move |_, _, cx| {
-                                            view.update(cx, |this, cx| {
-                                                this.ai_commit_and_push_for_current_thread(cx);
-                                            });
-                                        }
-                                    }),
-                                )
-                                .item(
-                                    PopupMenuItem::new(create_branch_label.clone()).on_click({
-                                        let view = view.clone();
-                                        move |_, window, cx| {
-                                            view.update(cx, |this, cx| {
-                                                this.ai_create_branch_and_push_for_current_thread(
-                                                    window, cx,
-                                                );
-                                            });
-                                        }
-                                    }),
-                                )
-                                .item(PopupMenuItem::separator())
-                                .item(
-                                    PopupMenuItem::new("Open PR").on_click({
-                                        let view = view.clone();
-                                        move |_, window, cx| {
-                                            view.update(cx, |this, cx| {
-                                                this.ai_open_pr_for_current_thread(window, cx);
-                                            });
-                                        }
-                                    }),
-                                )
-                            })
-                            .into_any_element()
-                    })
-                    .when_some(state.ai_managed_worktree_target.clone(), |this, target| {
-                        let view = view.clone();
-                        let tooltip = state.ai_delete_worktree_blocker.clone().unwrap_or_else(|| {
-                            format!("Delete managed worktree '{}' after the thread is done.", target.name)
-                        });
-                        this.child(
-                            Button::new("ai-delete-worktree")
-                                .compact()
-                                .danger()
-                                .with_size(gpui_component::Size::Small)
-                                .rounded(px(8.0))
-                                .icon(Icon::new(IconName::Delete).size(px(14.0)))
-                                .label("Delete Worktree")
-                                .tooltip(tooltip)
-                                .loading(state.ai_delete_worktree_loading)
-                                .disabled(state.ai_delete_worktree_blocker.is_some())
-                                .on_click(move |_, window, cx| {
-                                    view.update(cx, |this, cx| {
-                                        this.ai_confirm_delete_current_worktree_action(window, cx);
-                                    });
-                                }),
-                        )
-                    })
-                    .when(self.ai_mad_max_mode, |this| {
-                        this.child(
-                            div()
-                                .text_xs()
-                                .text_color(cx.theme().danger)
-                                .child("Full access enabled"),
-                        )
-                            }),
-                    ),
-            )
+            .child(h_flex().flex_1().justify_end().child(workspace_actions))
             .into_any_element()
     }
 

--- a/crates/hunk-desktop/src/app/render/ai_workspace_surface.rs
+++ b/crates/hunk-desktop/src/app/render/ai_workspace_surface.rs
@@ -111,6 +111,7 @@ impl DiffViewer {
                                 &surface,
                                 viewport_width_px.max(1),
                                 hovered_block_id.as_deref(),
+                                self.current_ai_workspace_kind() != AiWorkspaceKind::Chats,
                                 AiWorkspaceOverlayColors {
                                     muted_foreground: cx.theme().muted_foreground,
                                     border: cx.theme().border,
@@ -132,6 +133,7 @@ fn ai_workspace_overlay_action_clusters(
     surface: &ai_workspace_session::AiWorkspaceSurfaceSnapshot,
     viewport_width_px: usize,
     hovered_block_id: Option<&str>,
+    show_run_in_terminal_actions: bool,
     colors: AiWorkspaceOverlayColors,
 ) -> Vec<AnyElement> {
     let mut actions = Vec::new();
@@ -140,7 +142,9 @@ fn ai_workspace_overlay_action_clusters(
         let message_copy = block.block.copy_tooltip == Some("Copy message");
         let block_hovered = hovered_block_id == Some(block.block.id.as_str());
         let mut block_buttons = Vec::new();
-        if let Some(command) = block.block.run_in_terminal_command.clone() {
+        if show_run_in_terminal_actions
+            && let Some(command) = block.block.run_in_terminal_command.clone()
+        {
             block_buttons.push(AiWorkspaceOverlayButton {
                 id: format!("ai-workspace-run-terminal-{}", block.block.id),
                 tooltip: "Run in terminal",

--- a/crates/hunk-desktop/src/app/types.rs
+++ b/crates/hunk-desktop/src/app/types.rs
@@ -380,8 +380,33 @@ struct ParkedTerminalRuntimeHandle<R> {
 
 type AiHiddenTerminalRuntimeHandle = ParkedTerminalRuntimeHandle<AiTerminalRuntimeHandle>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AiWorkspaceKind {
+    Project,
+    Chats,
+}
+
+impl AiWorkspaceKind {
+    const fn shows_repo_actions(self) -> bool {
+        matches!(self, Self::Project)
+    }
+
+    const fn shows_mode_badge(self) -> bool {
+        matches!(self, Self::Project)
+    }
+
+    const fn shows_thread_mode_picker(self) -> bool {
+        matches!(self, Self::Project)
+    }
+
+    const fn shows_terminal(self) -> bool {
+        matches!(self, Self::Project)
+    }
+}
+
 #[derive(Debug, Clone)]
 struct AiVisibleThreadProjectSection {
+    workspace_kind: AiWorkspaceKind,
     project_root: PathBuf,
     project_label: String,
     threads: Vec<hunk_codex::state::ThreadSummary>,
@@ -393,6 +418,7 @@ struct AiVisibleThreadProjectSection {
 #[derive(Debug, Clone)]
 enum AiThreadSidebarRowKind {
     ProjectHeader {
+        workspace_kind: AiWorkspaceKind,
         project_root: PathBuf,
         project_label: String,
         total_thread_count: usize,
@@ -401,9 +427,11 @@ enum AiThreadSidebarRowKind {
         thread: hunk_codex::state::ThreadSummary,
     },
     EmptyProject {
+        workspace_kind: AiWorkspaceKind,
         project_root: PathBuf,
     },
     ProjectFooter {
+        workspace_kind: AiWorkspaceKind,
         project_root: PathBuf,
         hidden_thread_count: usize,
         expanded: bool,
@@ -417,6 +445,7 @@ struct AiThreadSidebarRow {
 
 #[derive(Debug, Clone)]
 struct AiVisibleFrameState {
+    workspace_kind: AiWorkspaceKind,
     project_count: usize,
     visible_thread_count: usize,
     threads_loading: bool,


### PR DESCRIPTION
Introduce a dedicated Chats workspace root and thread grouping, and disable repo-oriented AI actions there so chats behave as a separate workspace.