### PR TITLE
Smooth AI workspace streaming updates

### DIFF
--- a/crates/hunk-desktop/src/app.rs
+++ b/crates/hunk-desktop/src/app.rs
@@ -1454,6 +1454,8 @@ struct DiffViewer {
     ai_thread_sidebar_list_state: ListState,
     ai_thread_sidebar_row_count: usize,
     ai_workspace_session: Option<ai_workspace_session::AiWorkspaceSession>,
+    ai_workspace_streaming_reveal_task: Task<()>,
+    ai_workspace_streaming_reveal_active: bool,
     ai_workspace_surface_scroll_handle: ScrollHandle,
     ai_workspace_surface_last_scroll_offset: Option<Point<Pixels>>,
     ai_inline_review_surface: AiInlineReviewSurfaceState,

--- a/crates/hunk-desktop/src/app/ai_workspace_session.rs
+++ b/crates/hunk-desktop/src/app/ai_workspace_session.rs
@@ -211,6 +211,8 @@ pub(crate) struct AiWorkspaceSession {
     thread_id: String,
     source_rows: Arc<[AiWorkspaceSourceRow]>,
     blocks: Vec<AiWorkspaceBlock>,
+    source_row_block_ranges: BTreeMap<String, Range<usize>>,
+    streaming_previews_by_block_id: BTreeMap<String, AiWorkspaceStreamingPreview>,
     selection_scope_id: String,
     geometry_by_width_bucket: BTreeMap<usize, AiWorkspaceDisplayGeometry>,
     selection_surfaces_by_width_bucket: BTreeMap<usize, Arc<[AiTextSelectionSurfaceSpec]>>,
@@ -220,14 +222,24 @@ impl AiWorkspaceSession {
     pub(crate) fn new(
         thread_id: impl Into<String>,
         source_rows: Arc<[AiWorkspaceSourceRow]>,
-        blocks: Vec<AiWorkspaceBlock>,
+        blocks_by_source_row: Vec<Vec<AiWorkspaceBlock>>,
     ) -> Self {
         let thread_id = thread_id.into();
         let selection_scope_id = format!("ai-workspace-thread:{thread_id}");
+        let mut blocks = Vec::new();
+        let mut source_row_block_ranges = BTreeMap::new();
+        for (source_row, row_blocks) in source_rows.iter().zip(blocks_by_source_row) {
+            let start = blocks.len();
+            blocks.extend(row_blocks);
+            source_row_block_ranges.insert(source_row.row_id.clone(), start..blocks.len());
+        }
+        debug_assert_eq!(source_rows.len(), source_row_block_ranges.len());
         Self {
             thread_id,
             source_rows,
             blocks,
+            source_row_block_ranges,
+            streaming_previews_by_block_id: BTreeMap::new(),
             selection_scope_id,
             geometry_by_width_bucket: BTreeMap::new(),
             selection_surfaces_by_width_bucket: BTreeMap::new(),
@@ -970,4 +982,5 @@ fn ai_workspace_wrap_structured_preview_lines(
     )
 }
 
+include!("ai_workspace_session_streaming.rs");
 include!("ai_workspace_session_projection.rs");

--- a/crates/hunk-desktop/src/app/ai_workspace_session_streaming.rs
+++ b/crates/hunk-desktop/src/app/ai_workspace_session_streaming.rs
@@ -95,8 +95,6 @@ impl AiWorkspaceSession {
             .cloned()
             .collect::<Vec<_>>();
         let mut changed_block_indexes = Vec::new();
-        let mut selection_surfaces_changed = false;
-
         for block_id in pending_block_ids {
             let Some(block_index) = self.block_index(block_id.as_str()) else {
                 self.streaming_previews_by_block_id.remove(block_id.as_str());
@@ -128,7 +126,6 @@ impl AiWorkspaceSession {
             if copy_tracks_preview {
                 next_block.copy_text = Some(next_block.preview.clone());
             }
-            selection_surfaces_changed |= reveal_completed;
             self.blocks[block_index] = next_block;
             changed_block_indexes.push(block_index);
 
@@ -142,9 +139,7 @@ impl AiWorkspaceSession {
         }
 
         self.update_geometry_for_block_changes(changed_block_indexes.as_slice());
-        if selection_surfaces_changed {
-            self.selection_surfaces_by_width_bucket.clear();
-        }
+        self.selection_surfaces_by_width_bucket.clear();
         true
     }
 

--- a/crates/hunk-desktop/src/app/ai_workspace_session_streaming.rs
+++ b/crates/hunk-desktop/src/app/ai_workspace_session_streaming.rs
@@ -1,0 +1,267 @@
+const AI_WORKSPACE_STREAMING_REVEAL_TICK_MS: u64 = 16;
+const AI_WORKSPACE_STREAMING_REVEAL_TARGET_MS: u64 = 200;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AiWorkspaceStreamingPreview {
+    target_preview: String,
+    bytes_per_tick: usize,
+}
+
+impl AiWorkspaceSession {
+    pub(crate) fn has_pending_streaming_preview(&self) -> bool {
+        !self.streaming_previews_by_block_id.is_empty()
+    }
+
+    pub(crate) fn replace_source_row(
+        &mut self,
+        source_row: AiWorkspaceSourceRow,
+        next_blocks: Vec<AiWorkspaceBlock>,
+        smooth_preview: bool,
+    ) -> bool {
+        let Some(range) = self.source_row_block_ranges.get(source_row.row_id.as_str()).cloned() else {
+            return false;
+        };
+        if range.len() != next_blocks.len() {
+            return false;
+        }
+
+        let row_index = self
+            .source_rows
+            .iter()
+            .position(|entry| entry.row_id == source_row.row_id);
+        let Some(row_index) = row_index else {
+            return false;
+        };
+
+        let mut changed_block_indexes = Vec::new();
+        let mut selection_surfaces_changed = false;
+
+        for (offset, mut next_block) in next_blocks.into_iter().enumerate() {
+            let block_index = range.start + offset;
+            let Some(current_block) = self.blocks.get(block_index).cloned() else {
+                return false;
+            };
+            if current_block.id != next_block.id {
+                return false;
+            }
+
+            let pending_preview = smooth_preview
+                .then(|| ai_workspace_streaming_preview_update(&current_block, &next_block))
+                .flatten();
+            if let Some(pending_preview) = pending_preview {
+                let copy_tracks_preview =
+                    next_block.copy_text.as_deref() == Some(next_block.preview.as_str());
+                next_block.preview = current_block.preview.clone();
+                if copy_tracks_preview {
+                    next_block.copy_text = Some(current_block.preview.clone());
+                }
+                self.streaming_previews_by_block_id
+                    .insert(next_block.id.clone(), pending_preview);
+            } else {
+                self.streaming_previews_by_block_id.remove(next_block.id.as_str());
+            }
+
+            if current_block != next_block {
+                selection_surfaces_changed |= current_block.title != next_block.title
+                    || current_block.preview != next_block.preview;
+                self.blocks[block_index] = next_block;
+                changed_block_indexes.push(block_index);
+            }
+        }
+
+        if let Some(source_rows) = Arc::get_mut(&mut self.source_rows) {
+            source_rows[row_index] = source_row;
+        } else {
+            let mut source_rows = self.source_rows.to_vec();
+            source_rows[row_index] = source_row;
+            self.source_rows = Arc::<[AiWorkspaceSourceRow]>::from(source_rows);
+        }
+
+        if changed_block_indexes.is_empty() {
+            return true;
+        }
+
+        self.update_geometry_for_block_changes(changed_block_indexes.as_slice());
+        if selection_surfaces_changed {
+            self.selection_surfaces_by_width_bucket.clear();
+        }
+        true
+    }
+
+    pub(crate) fn reveal_pending_streaming_preview_step(&mut self) -> bool {
+        let pending_block_ids = self
+            .streaming_previews_by_block_id
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut changed_block_indexes = Vec::new();
+        let mut selection_surfaces_changed = false;
+
+        for block_id in pending_block_ids {
+            let Some(block_index) = self.block_index(block_id.as_str()) else {
+                self.streaming_previews_by_block_id.remove(block_id.as_str());
+                continue;
+            };
+            let Some(pending_preview) = self
+                .streaming_previews_by_block_id
+                .get(block_id.as_str())
+                .cloned()
+            else {
+                continue;
+            };
+            let Some(current_block) = self.blocks.get(block_index).cloned() else {
+                self.streaming_previews_by_block_id.remove(block_id.as_str());
+                continue;
+            };
+
+            let next_preview =
+                ai_workspace_streaming_reveal_preview(current_block.preview.as_str(), &pending_preview);
+            if next_preview == current_block.preview {
+                continue;
+            }
+
+            let reveal_completed = next_preview == pending_preview.target_preview;
+            let mut next_block = current_block.clone();
+            let copy_tracks_preview =
+                next_block.copy_text.as_deref() == Some(current_block.preview.as_str());
+            next_block.preview = next_preview;
+            if copy_tracks_preview {
+                next_block.copy_text = Some(next_block.preview.clone());
+            }
+            selection_surfaces_changed |= reveal_completed;
+            self.blocks[block_index] = next_block;
+            changed_block_indexes.push(block_index);
+
+            if reveal_completed {
+                self.streaming_previews_by_block_id.remove(block_id.as_str());
+            }
+        }
+
+        if changed_block_indexes.is_empty() {
+            return false;
+        }
+
+        self.update_geometry_for_block_changes(changed_block_indexes.as_slice());
+        if selection_surfaces_changed {
+            self.selection_surfaces_by_width_bucket.clear();
+        }
+        true
+    }
+
+    fn update_geometry_for_block_changes(&mut self, changed_block_indexes: &[usize]) {
+        if changed_block_indexes.is_empty() {
+            return;
+        }
+
+        let mut changed_block_indexes = changed_block_indexes.to_vec();
+        changed_block_indexes.sort_unstable();
+        changed_block_indexes.dedup();
+
+        for (width_bucket, geometry) in &mut self.geometry_by_width_bucket {
+            let mut total_height_delta = 0isize;
+            for &block_index in &changed_block_indexes {
+                let Some(block) = self.blocks.get(block_index) else {
+                    continue;
+                };
+                let Some(entry) = geometry.blocks.get_mut(block_index) else {
+                    continue;
+                };
+
+                let next_height_px =
+                    ai_workspace_text_layout_for_block(block, *width_bucket).height_px;
+                let previous_height_px = entry.height_px;
+                if next_height_px == previous_height_px {
+                    continue;
+                }
+
+                let height_delta = next_height_px as isize - previous_height_px as isize;
+                entry.height_px = next_height_px;
+                total_height_delta += height_delta;
+                for shifted_entry in geometry.blocks.iter_mut().skip(block_index + 1) {
+                    shifted_entry.top_px = shifted_entry.top_px.saturating_add_signed(height_delta);
+                }
+            }
+
+            if total_height_delta != 0 {
+                geometry.total_surface_height_px = geometry
+                    .total_surface_height_px
+                    .saturating_add_signed(total_height_delta);
+                self.selection_surfaces_by_width_bucket.remove(width_bucket);
+            }
+        }
+    }
+}
+
+fn ai_workspace_streaming_preview_update(
+    current_block: &AiWorkspaceBlock,
+    next_block: &AiWorkspaceBlock,
+) -> Option<AiWorkspaceStreamingPreview> {
+    if current_block.preview == next_block.preview {
+        return None;
+    }
+    if current_block.title != next_block.title
+        || current_block.kind != next_block.kind
+        || current_block.role != next_block.role
+        || current_block.mono_preview != next_block.mono_preview
+        || current_block.expandable != next_block.expandable
+        || current_block.expanded != next_block.expanded
+    {
+        return None;
+    }
+    if !next_block.preview.starts_with(current_block.preview.as_str()) {
+        return None;
+    }
+
+    let remaining_bytes = next_block
+        .preview
+        .len()
+        .saturating_sub(current_block.preview.len());
+    if remaining_bytes == 0 {
+        return None;
+    }
+
+    let steps = AI_WORKSPACE_STREAMING_REVEAL_TARGET_MS
+        .div_ceil(AI_WORKSPACE_STREAMING_REVEAL_TICK_MS)
+        .max(1) as usize;
+    Some(AiWorkspaceStreamingPreview {
+        target_preview: next_block.preview.clone(),
+        bytes_per_tick: remaining_bytes.div_ceil(steps).max(1),
+    })
+}
+
+fn ai_workspace_streaming_reveal_preview(
+    current_preview: &str,
+    pending_preview: &AiWorkspaceStreamingPreview,
+) -> String {
+    let current_len = current_preview.len();
+    if current_len >= pending_preview.target_preview.len() {
+        return pending_preview.target_preview.clone();
+    }
+
+    let next_len = ai_workspace_streaming_next_boundary(
+        pending_preview.target_preview.as_str(),
+        current_len,
+        pending_preview.bytes_per_tick,
+    );
+    pending_preview.target_preview[..next_len].to_string()
+}
+
+fn ai_workspace_streaming_next_boundary(
+    preview: &str,
+    current_len: usize,
+    bytes_per_tick: usize,
+) -> usize {
+    let target_len = preview.len().min(current_len.saturating_add(bytes_per_tick));
+    if target_len >= preview.len() {
+        return preview.len();
+    }
+    if preview.is_char_boundary(target_len) {
+        return target_len;
+    }
+
+    let mut next_len = target_len;
+    while next_len < preview.len() && !preview.is_char_boundary(next_len) {
+        next_len += 1;
+    }
+    next_len.min(preview.len())
+}

--- a/crates/hunk-desktop/src/app/controller/ai/runtime.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime.rs
@@ -7,6 +7,7 @@ struct AiPreparedThreadWorkspace {
 }
 
 include!("runtime_events.rs");
+include!("runtime_streaming.rs");
 
 impl DiffViewer {
     fn should_ignore_transient_visible_ai_snapshot(
@@ -61,6 +62,27 @@ impl DiffViewer {
             .as_deref()
             .map(|thread_id| thread_latest_timeline_sequence(&self.ai_state_snapshot, thread_id))
             .unwrap_or(0);
+        if self.should_ignore_transient_visible_ai_snapshot(
+            &snapshot.state,
+            snapshot.active_thread_id.as_deref(),
+        ) {
+            debug!(
+                selected_thread_id = previous_selected_thread.as_deref().unwrap_or("<none>"),
+                current_threads = self.ai_state_snapshot.threads.len(),
+                next_threads = snapshot.state.threads.len(),
+                next_active_thread_id = snapshot.active_thread_id.as_deref().unwrap_or("<none>"),
+                "ignoring transient visible AI snapshot that would evict the current thread"
+            );
+            return;
+        }
+        let Some(snapshot) = self.try_apply_incremental_ai_streaming_snapshot(
+            snapshot,
+            previous_selected_thread.as_deref(),
+            previous_selected_thread_sequence,
+            cx,
+        ) else {
+            return;
+        };
         let AiSnapshot {
             state,
             active_thread_id,
@@ -78,16 +100,6 @@ impl DiffViewer {
             include_hidden_models,
             mad_max_mode,
         } = snapshot;
-        if self.should_ignore_transient_visible_ai_snapshot(&state, active_thread_id.as_deref()) {
-            debug!(
-                selected_thread_id = previous_selected_thread.as_deref().unwrap_or("<none>"),
-                current_threads = self.ai_state_snapshot.threads.len(),
-                next_threads = state.threads.len(),
-                next_active_thread_id = active_thread_id.as_deref().unwrap_or("<none>"),
-                "ignoring transient visible AI snapshot that would evict the current thread"
-            );
-            return;
-        }
         let changed_row_ids = previous_selected_thread
             .as_deref()
             .map(|thread_id| {

--- a/crates/hunk-desktop/src/app/controller/ai/runtime_streaming.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime_streaming.rs
@@ -44,6 +44,31 @@ impl DiffViewer {
         }) else {
             return Some(snapshot);
         };
+        let threads_changed = ai_snapshot_threads_changed(&self.ai_state_snapshot, &snapshot.state);
+
+        let AiSnapshot { state, .. } = snapshot;
+        self.ai_state_snapshot = state;
+        self.rebuild_ai_timeline_indexes();
+        if threads_changed {
+            self.rebuild_ai_thread_sidebar_state();
+        }
+
+        let next_visible_row_ids = self.ai_timeline_visible_rows_for_thread(selected_thread_id).3;
+        if next_visible_row_ids != visible_row_ids {
+            self.invalidate_ai_visible_frame_state_with_reason("runtime");
+            if self.ai_timeline_follow_output
+                && should_scroll_timeline_to_bottom_on_new_activity(
+                    thread_latest_timeline_sequence(&self.ai_state_snapshot, selected_thread_id),
+                    previous_selected_thread_sequence,
+                    self.ai_timeline_follow_output,
+                )
+            {
+                self.ai_scroll_timeline_to_bottom = true;
+            }
+            self.flush_ai_timeline_scroll_request();
+            cx.notify();
+            return None;
+        }
 
         let changed_container_row_ids = change_set
             .changed_item_keys
@@ -54,10 +79,7 @@ impl DiffViewer {
             })
             .collect::<std::collections::BTreeSet<_>>();
 
-        let AiSnapshot { state, .. } = snapshot;
-        self.ai_state_snapshot = state;
-
-        let visible_row_id_set = visible_row_ids
+        let visible_row_id_set = next_visible_row_ids
             .iter()
             .map(String::as_str)
             .collect::<std::collections::BTreeSet<_>>();

--- a/crates/hunk-desktop/src/app/controller/ai/runtime_streaming.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/runtime_streaming.rs
@@ -1,0 +1,275 @@
+const AI_WORKSPACE_STREAMING_REVEAL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(16);
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct AiIncrementalStreamingChangeSet {
+    changed_item_keys: std::collections::BTreeSet<String>,
+}
+
+impl DiffViewer {
+    fn try_apply_incremental_ai_streaming_snapshot(
+        &mut self,
+        snapshot: AiSnapshot,
+        previous_selected_thread: Option<&str>,
+        previous_selected_thread_sequence: u64,
+        cx: &mut Context<Self>,
+    ) -> Option<AiSnapshot> {
+        let Some(selected_thread_id) = previous_selected_thread else {
+            return Some(snapshot);
+        };
+        if self.workspace_view_mode != WorkspaceViewMode::Ai
+            || self.ai_visible_frame_state.is_none()
+            || self.ai_workspace_session.is_none()
+            || self.ai_new_thread_draft_active
+            || self.ai_pending_new_thread_selection
+            || self.ai_pending_thread_start.is_some()
+            || snapshot.active_thread_id.as_deref() != self.ai_selected_thread_id.as_deref()
+            || !ai_snapshot_supports_incremental_streaming(self, &snapshot)
+        {
+            return Some(snapshot);
+        }
+
+        let Some(change_set) =
+            ai_incremental_streaming_change_set(&self.ai_state_snapshot, &snapshot.state)
+        else {
+            return Some(snapshot);
+        };
+        if change_set.changed_item_keys.is_empty() {
+            return Some(snapshot);
+        }
+
+        let Some(visible_row_ids) = self.ai_visible_frame_state.as_ref().and_then(|state| {
+            (state.selected_thread_id.as_deref() == Some(selected_thread_id))
+                .then(|| state.timeline_visible_row_ids.iter().cloned().collect::<Vec<_>>())
+        }) else {
+            return Some(snapshot);
+        };
+
+        let changed_container_row_ids = change_set
+            .changed_item_keys
+            .iter()
+            .filter_map(|item_key| {
+                let row_id = format!("item:{item_key}");
+                self.ai_timeline_container_row_id(row_id.as_str())
+            })
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let AiSnapshot { state, .. } = snapshot;
+        self.ai_state_snapshot = state;
+
+        let visible_row_id_set = visible_row_ids
+            .iter()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>();
+        let row_updates = changed_container_row_ids
+            .iter()
+            .filter(|row_id| visible_row_id_set.contains(row_id.as_str()))
+            .filter_map(|row_id| {
+                let source_row = self.ai_workspace_source_row(row_id.as_str())?;
+                let blocks = self.ai_workspace_blocks_for_row(row_id.as_str());
+                Some((source_row, blocks))
+            })
+            .collect::<Vec<_>>();
+
+        let mut fallback_to_full_rebuild = false;
+        let mut revealed_immediately = false;
+        if let Some(session) = self.ai_workspace_session.as_mut() {
+            for (source_row, blocks) in &row_updates {
+                if !session.replace_source_row(source_row.clone(), blocks.clone(), true) {
+                    fallback_to_full_rebuild = true;
+                    break;
+                }
+            }
+            if !fallback_to_full_rebuild {
+                revealed_immediately = session.reveal_pending_streaming_preview_step();
+            }
+        }
+
+        if fallback_to_full_rebuild {
+            self.rebuild_ai_timeline_indexes();
+            self.invalidate_ai_visible_frame_state_with_reason("runtime");
+            cx.notify();
+            return None;
+        }
+
+        let changed_visible_row_ids = changed_container_row_ids
+            .iter()
+            .filter(|row_id| visible_row_id_set.contains(row_id.as_str()))
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+        self.ai_clear_text_selection_for_rows(&changed_visible_row_ids, cx);
+
+        if self.ai_timeline_follow_output
+            && should_scroll_timeline_to_bottom_on_new_activity(
+                thread_latest_timeline_sequence(&self.ai_state_snapshot, selected_thread_id),
+                previous_selected_thread_sequence,
+                self.ai_timeline_follow_output,
+            )
+        {
+            self.ai_scroll_timeline_to_bottom = true;
+        }
+        if revealed_immediately {
+            self.ai_scroll_timeline_to_bottom |= self.ai_timeline_follow_output;
+        }
+
+        self.ensure_ai_workspace_streaming_reveal_task(cx);
+        self.flush_ai_timeline_scroll_request();
+        cx.notify();
+        None
+    }
+
+    fn ensure_ai_workspace_streaming_reveal_task(&mut self, cx: &mut Context<Self>) {
+        let has_pending_preview = self
+            .ai_workspace_session
+            .as_ref()
+            .is_some_and(ai_workspace_session::AiWorkspaceSession::has_pending_streaming_preview);
+        if self.ai_workspace_streaming_reveal_active || !has_pending_preview {
+            return;
+        }
+
+        self.ai_workspace_streaming_reveal_active = true;
+        self.ai_workspace_streaming_reveal_task = cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(AI_WORKSPACE_STREAMING_REVEAL_INTERVAL)
+                    .await;
+
+                let Some(this) = this.upgrade() else {
+                    return;
+                };
+
+                let mut keep_running = false;
+                this.update(cx, |this, cx| {
+                    let (revealed, has_pending_preview) = this
+                        .ai_workspace_session
+                        .as_mut()
+                        .map(|session| {
+                            (
+                                session.reveal_pending_streaming_preview_step(),
+                                session.has_pending_streaming_preview(),
+                            )
+                        })
+                        .unwrap_or((false, false));
+
+                    keep_running = has_pending_preview;
+                    if !keep_running {
+                        this.ai_workspace_streaming_reveal_active = false;
+                    }
+
+                    if revealed {
+                        if this.ai_timeline_follow_output && this.ai_selected_thread_id.is_some() {
+                            this.ai_scroll_timeline_to_bottom = true;
+                            this.flush_ai_timeline_scroll_request();
+                        }
+                        cx.notify();
+                    }
+                });
+
+                if !keep_running {
+                    return;
+                }
+            }
+        });
+    }
+}
+
+fn ai_snapshot_supports_incremental_streaming(this: &DiffViewer, snapshot: &AiSnapshot) -> bool {
+    this.ai_pending_approvals == snapshot.pending_approvals
+        && this.ai_pending_user_inputs == snapshot.pending_user_inputs
+        && this.ai_account == snapshot.account
+        && this.ai_requires_openai_auth == snapshot.requires_openai_auth
+        && this.ai_pending_chatgpt_login_id == snapshot.pending_chatgpt_login_id
+        && this.ai_pending_chatgpt_auth_url == snapshot.pending_chatgpt_auth_url
+        && this.ai_rate_limits == snapshot.rate_limits
+        && this.ai_models == snapshot.models
+        && this.ai_experimental_features == snapshot.experimental_features
+        && this.ai_collaboration_modes == snapshot.collaboration_modes
+        && this.ai_skills == snapshot.skills
+        && this.ai_include_hidden_models == snapshot.include_hidden_models
+        && this.ai_mad_max_mode == snapshot.mad_max_mode
+}
+
+fn ai_incremental_streaming_change_set(
+    previous_state: &hunk_codex::state::AiState,
+    next_state: &hunk_codex::state::AiState,
+) -> Option<AiIncrementalStreamingChangeSet> {
+    if previous_state.thread_token_usage != next_state.thread_token_usage
+        || previous_state.turn_diffs != next_state.turn_diffs
+        || previous_state.turn_plans != next_state.turn_plans
+        || previous_state.server_requests != next_state.server_requests
+        || previous_state.active_thread_by_cwd != next_state.active_thread_by_cwd
+        || previous_state.threads.len() != next_state.threads.len()
+        || previous_state.turns.len() != next_state.turns.len()
+        || previous_state.items.len() != next_state.items.len()
+    {
+        return None;
+    }
+
+    for (thread_id, previous_thread) in &previous_state.threads {
+        let next_thread = next_state.threads.get(thread_id.as_str())?;
+        if !ai_thread_supports_incremental_streaming(previous_thread, next_thread) {
+            return None;
+        }
+    }
+
+    for (turn_key, previous_turn) in &previous_state.turns {
+        let next_turn = next_state.turns.get(turn_key.as_str())?;
+        if !ai_turn_supports_incremental_streaming(previous_turn, next_turn) {
+            return None;
+        }
+    }
+
+    let mut changed_item_keys = std::collections::BTreeSet::new();
+    for (item_key, previous_item) in &previous_state.items {
+        let next_item = next_state.items.get(item_key.as_str())?;
+        let changed = ai_item_supports_incremental_streaming(previous_item, next_item)?;
+        if changed {
+            changed_item_keys.insert(item_key.clone());
+        }
+    }
+
+    Some(AiIncrementalStreamingChangeSet { changed_item_keys })
+}
+
+fn ai_thread_supports_incremental_streaming(
+    previous_thread: &hunk_codex::state::ThreadSummary,
+    next_thread: &hunk_codex::state::ThreadSummary,
+) -> bool {
+    previous_thread.id == next_thread.id
+        && previous_thread.cwd == next_thread.cwd
+        && previous_thread.title == next_thread.title
+        && previous_thread.status == next_thread.status
+        && previous_thread.created_at == next_thread.created_at
+}
+
+fn ai_turn_supports_incremental_streaming(
+    previous_turn: &hunk_codex::state::TurnSummary,
+    next_turn: &hunk_codex::state::TurnSummary,
+) -> bool {
+    previous_turn.id == next_turn.id
+        && previous_turn.thread_id == next_turn.thread_id
+        && previous_turn.collaboration_mode == next_turn.collaboration_mode
+        && previous_turn.status == next_turn.status
+}
+
+fn ai_item_supports_incremental_streaming(
+    previous_item: &hunk_codex::state::ItemSummary,
+    next_item: &hunk_codex::state::ItemSummary,
+) -> Option<bool> {
+    if previous_item.id != next_item.id
+        || previous_item.thread_id != next_item.thread_id
+        || previous_item.turn_id != next_item.turn_id
+        || previous_item.kind != next_item.kind
+        || ai_timeline_item_is_renderable_for_layout(previous_item)
+            != ai_timeline_item_is_renderable_for_layout(next_item)
+    {
+        return None;
+    }
+
+    Some(
+        previous_item.status != next_item.status
+            || previous_item.content != next_item.content
+            || previous_item.display_metadata != next_item.display_metadata
+            || previous_item.last_sequence != next_item.last_sequence,
+    )
+}

--- a/crates/hunk-desktop/src/app/controller/ai/tests.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests.rs
@@ -371,5 +371,6 @@ mod ai_tests {
     include!("tests/followup_prompts.rs");
     include!("tests/composer_status_scope.rs");
     include!("tests/workspace_surface_plan_items.rs");
+    include!("tests/workspace_streaming.rs");
     include!("tests/text_selection.rs");
 }

--- a/crates/hunk-desktop/src/app/controller/ai/tests/workspace_streaming.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/tests/workspace_streaming.rs
@@ -1,0 +1,168 @@
+#[test]
+fn incremental_streaming_change_set_accepts_item_content_updates() {
+    let item_key = hunk_codex::state::item_storage_key("thread-1", "turn-1", "item-1");
+    let turn_key = hunk_codex::state::turn_storage_key("thread-1", "turn-1");
+    let mut previous = AiState::default();
+    previous.threads.insert(
+        "thread-1".to_string(),
+        ThreadSummary {
+            id: "thread-1".to_string(),
+            cwd: "/repo".to_string(),
+            title: Some("Thread".to_string()),
+            status: ThreadLifecycleStatus::Active,
+            created_at: 1,
+            updated_at: 1,
+            last_sequence: 1,
+        },
+    );
+    previous.turns.insert(
+        turn_key.clone(),
+        hunk_codex::state::TurnSummary {
+            id: "turn-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            collaboration_mode: None,
+            status: hunk_codex::state::TurnStatus::InProgress,
+            last_sequence: 1,
+        },
+    );
+    previous.items.insert(
+        item_key.clone(),
+        timeline_tool_item(
+            "item-1",
+            "thread-1",
+            "turn-1",
+            "agentMessage",
+            ItemStatus::Streaming,
+            "Hello",
+            "{}",
+            1,
+        ),
+    );
+
+    let mut next = previous.clone();
+    next.threads.get_mut("thread-1").expect("thread").updated_at = 2;
+    next.threads.get_mut("thread-1").expect("thread").last_sequence = 2;
+    next.turns.get_mut(turn_key.as_str()).expect("turn").last_sequence = 2;
+    let item = next.items.get_mut(item_key.as_str()).expect("item");
+    item.content = "Hello world".to_string();
+    item.last_sequence = 2;
+
+    let changes = super::ai_incremental_streaming_change_set(&previous, &next)
+        .expect("content-only update should use incremental streaming");
+
+    assert_eq!(changes.changed_item_keys, BTreeSet::from([item_key]));
+}
+
+#[test]
+fn incremental_streaming_change_set_rejects_new_item_keys() {
+    let item_key = hunk_codex::state::item_storage_key("thread-1", "turn-1", "item-1");
+    let turn_key = hunk_codex::state::turn_storage_key("thread-1", "turn-1");
+    let mut previous = AiState::default();
+    previous.threads.insert(
+        "thread-1".to_string(),
+        ThreadSummary {
+            id: "thread-1".to_string(),
+            cwd: "/repo".to_string(),
+            title: Some("Thread".to_string()),
+            status: ThreadLifecycleStatus::Active,
+            created_at: 1,
+            updated_at: 1,
+            last_sequence: 1,
+        },
+    );
+    previous.turns.insert(
+        turn_key.clone(),
+        hunk_codex::state::TurnSummary {
+            id: "turn-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            collaboration_mode: None,
+            status: hunk_codex::state::TurnStatus::InProgress,
+            last_sequence: 1,
+        },
+    );
+    previous.items.insert(
+        item_key,
+        timeline_tool_item(
+            "item-1",
+            "thread-1",
+            "turn-1",
+            "agentMessage",
+            ItemStatus::Streaming,
+            "Hello",
+            "{}",
+            1,
+        ),
+    );
+
+    let mut next = previous.clone();
+    next.threads.get_mut("thread-1").expect("thread").updated_at = 2;
+    next.threads.get_mut("thread-1").expect("thread").last_sequence = 2;
+    next.turns.get_mut(turn_key.as_str()).expect("turn").last_sequence = 2;
+    next.items.insert(
+        hunk_codex::state::item_storage_key("thread-1", "turn-1", "item-2"),
+        timeline_tool_item(
+            "item-2",
+            "thread-1",
+            "turn-1",
+            "agentMessage",
+            ItemStatus::Streaming,
+            "Second",
+            "{}",
+            2,
+        ),
+    );
+
+    assert!(super::ai_incremental_streaming_change_set(&previous, &next).is_none());
+}
+
+#[test]
+fn incremental_streaming_change_set_rejects_renderability_flips() {
+    let item_key = hunk_codex::state::item_storage_key("thread-1", "turn-1", "item-1");
+    let turn_key = hunk_codex::state::turn_storage_key("thread-1", "turn-1");
+    let mut previous = AiState::default();
+    previous.threads.insert(
+        "thread-1".to_string(),
+        ThreadSummary {
+            id: "thread-1".to_string(),
+            cwd: "/repo".to_string(),
+            title: Some("Thread".to_string()),
+            status: ThreadLifecycleStatus::Active,
+            created_at: 1,
+            updated_at: 1,
+            last_sequence: 1,
+        },
+    );
+    previous.turns.insert(
+        turn_key.clone(),
+        hunk_codex::state::TurnSummary {
+            id: "turn-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            collaboration_mode: None,
+            status: hunk_codex::state::TurnStatus::InProgress,
+            last_sequence: 1,
+        },
+    );
+    previous.items.insert(
+        item_key.clone(),
+        hunk_codex::state::ItemSummary {
+            id: "item-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            kind: "reasoning".to_string(),
+            status: ItemStatus::Streaming,
+            content: String::new(),
+            display_metadata: None,
+            last_sequence: 1,
+        },
+    );
+
+    let mut next = previous.clone();
+    next.threads.get_mut("thread-1").expect("thread").updated_at = 2;
+    next.threads.get_mut("thread-1").expect("thread").last_sequence = 2;
+    next.turns.get_mut(turn_key.as_str()).expect("turn").last_sequence = 2;
+    let item = next.items.get_mut(item_key.as_str()).expect("item");
+    item.content = "Thinking".to_string();
+    item.last_sequence = 2;
+
+    assert!(super::ai_incremental_streaming_change_set(&previous, &next).is_none());
+}

--- a/crates/hunk-desktop/src/app/controller/ai/workspace_surface.rs
+++ b/crates/hunk-desktop/src/app/controller/ai/workspace_surface.rs
@@ -281,21 +281,26 @@ impl DiffViewer {
             return;
         }
 
-        let blocks = visible_row_ids
+        let blocks_by_source_row = visible_row_ids
             .iter()
-            .flat_map(|row_id| self.ai_workspace_blocks_for_row(row_id.as_str()))
+            .map(|row_id| self.ai_workspace_blocks_for_row(row_id.as_str()))
             .collect::<Vec<_>>();
         if self
             .ai_workspace_selection
             .as_ref()
-            .is_some_and(|selection| !blocks.iter().any(|block| block.id == selection.block_id))
+            .is_some_and(|selection| {
+                !blocks_by_source_row
+                    .iter()
+                    .flatten()
+                    .any(|block| block.id == selection.block_id)
+            })
         {
             self.ai_workspace_selection = None;
         }
         self.ai_workspace_session = Some(ai_workspace_session::AiWorkspaceSession::new(
             thread_id.to_string(),
             Arc::<[ai_workspace_session::AiWorkspaceSourceRow]>::from(source_rows),
-            blocks,
+            blocks_by_source_row,
         ));
         self.record_ai_workspace_session_rebuild_timing(rebuild_started_at.elapsed());
     }
@@ -401,7 +406,7 @@ impl DiffViewer {
                     .map(|diff| vec![ai_workspace_diff_block(
                         row.id.clone(),
                         row.id.clone(),
-                        row.last_sequence,
+                        self.ai_workspace_turn_diff_last_sequence(turn_key.as_str(), row),
                         &crate::app::ai_workspace_timeline_projection::ai_workspace_turn_diff_summary(
                             diff,
                         ),
@@ -433,7 +438,7 @@ impl DiffViewer {
                     run_in_terminal_cwd: None,
                     status_label: None,
                     status_color_role: None,
-                    last_sequence: row.last_sequence,
+                    last_sequence: plan.last_sequence,
                     }])
                     .unwrap_or_default()
             }
@@ -535,24 +540,9 @@ impl DiffViewer {
         row_id: &str,
     ) -> Option<ai_workspace_session::AiWorkspaceSourceRow> {
         if let Some(row) = self.ai_timeline_row(row_id) {
-            let last_sequence = match &row.source {
-                AiTimelineRowSource::Group { group_id } => self
-                    .ai_timeline_group(group_id.as_str())
-                    .map(|group| self.ai_workspace_group_source_signature(row, group))
-                    .unwrap_or_else(|| {
-                        ai_workspace_row_signature(
-                            row.last_sequence,
-                            self.ai_workspace_row_is_expanded(row.id.as_str()),
-                        )
-                    }),
-                _ => ai_workspace_row_signature(
-                    row.last_sequence,
-                    self.ai_workspace_row_is_expanded(row.id.as_str()),
-                ),
-            };
             return Some(ai_workspace_session::AiWorkspaceSourceRow {
                 row_id: row.id.clone(),
-                last_sequence,
+                last_sequence: self.ai_workspace_source_signature_for_row(row),
             });
         }
         if let Some(pending) = self.ai_pending_steer_for_row_id(row_id) {
@@ -971,7 +961,7 @@ impl DiffViewer {
                 run_in_terminal_cwd: None,
                 status_label: None,
                 status_color_role: None,
-                last_sequence: row.last_sequence,
+                last_sequence: item.last_sequence,
                 })
             }
             None if item.kind == "fileChange" => crate::app::ai_workspace_timeline_projection::ai_workspace_file_change_summary(item)
@@ -979,7 +969,7 @@ impl DiffViewer {
                     ai_workspace_diff_block(
                         row.id.clone(),
                         row.id.clone(),
-                        row.last_sequence,
+                        item.last_sequence,
                         &summary,
                         nested,
                     )
@@ -1042,7 +1032,7 @@ impl DiffViewer {
                     status_color_role: Some(ai_workspace_command_status_color_role(
                         command_details.as_ref(),
                     )),
-                    last_sequence: row.last_sequence,
+                    last_sequence: item.last_sequence,
                 })
             }
             None
@@ -1104,7 +1094,7 @@ impl DiffViewer {
                         }),
                     status_color_role: (item.status != hunk_codex::state::ItemStatus::Completed)
                         .then_some(ai_workspace_session::AiWorkspacePreviewColorRole::Accent),
-                    last_sequence: row.last_sequence,
+                    last_sequence: item.last_sequence,
                 })
             }
             None => Some(ai_workspace_session::AiWorkspaceBlock {
@@ -1127,7 +1117,7 @@ impl DiffViewer {
                 run_in_terminal_cwd: None,
                 status_label: None,
                 status_color_role: None,
-                last_sequence: row.last_sequence,
+                last_sequence: item.last_sequence,
             }),
         }
     }
@@ -1143,13 +1133,14 @@ impl DiffViewer {
             return vec![ai_workspace_diff_block(
                 row.id.clone(),
                 row.id.clone(),
-                row.last_sequence,
+                self.ai_workspace_source_signature_for_row(row),
                 &summary,
                 false,
             )];
         }
 
         let expanded = self.ai_workspace_row_is_expanded(row.id.as_str());
+        let (group_title, group_summary) = self.ai_workspace_group_title_and_summary(group);
         let mut blocks = vec![ai_workspace_session::AiWorkspaceBlock {
             id: row.id.clone(),
             source_row_id: row.id.clone(),
@@ -1161,8 +1152,8 @@ impl DiffViewer {
             expandable: true,
             expanded,
             title: crate::app::ai_workspace_timeline_projection::ai_workspace_format_header_line(
-                group.title.as_str(),
-                group.summary.as_deref(),
+                group_title.as_str(),
+                group_summary.as_deref(),
                 None,
             ),
             preview: String::new(),
@@ -1174,7 +1165,7 @@ impl DiffViewer {
             run_in_terminal_cwd: None,
             status_label: None,
             status_color_role: None,
-            last_sequence: row.last_sequence,
+            last_sequence: self.ai_workspace_source_signature_for_row(row),
         }];
 
         if !expanded {
@@ -1200,7 +1191,7 @@ impl DiffViewer {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         std::hash::Hash::hash(
             &ai_workspace_row_signature(
-                row.last_sequence,
+                self.ai_workspace_row_content_last_sequence(row),
                 self.ai_workspace_row_is_expanded(row.id.as_str()),
             ),
             &mut hasher,
@@ -1211,7 +1202,7 @@ impl DiffViewer {
                 if let Some(child_row) = self.ai_timeline_row(child_row_id.as_str()) {
                     std::hash::Hash::hash(
                         &ai_workspace_row_signature(
-                            child_row.last_sequence,
+                            self.ai_workspace_row_content_last_sequence(child_row),
                             self.ai_workspace_row_is_expanded(child_row.id.as_str()),
                         ),
                         &mut hasher,
@@ -1221,5 +1212,77 @@ impl DiffViewer {
         }
 
         std::hash::Hasher::finish(&hasher)
+    }
+
+    fn ai_workspace_group_title_and_summary(
+        &self,
+        group: &AiTimelineGroup,
+    ) -> (String, Option<String>) {
+        let mut summary = None::<AiTimelineGroupSummary>;
+        for child_row_id in &group.child_row_ids {
+            let Some(child_row) = self.ai_timeline_row(child_row_id.as_str()) else {
+                continue;
+            };
+            let Some(next_summary) =
+                ai_timeline_group_summary_for_row(&self.ai_state_snapshot, child_row)
+            else {
+                continue;
+            };
+            if let Some(current_summary) = summary.as_mut() {
+                current_summary.merge(next_summary);
+            } else {
+                summary = Some(next_summary);
+            }
+        }
+
+        summary
+            .as_ref()
+            .map(|summary| ai_timeline_group_title_and_summary(summary, group.child_row_ids.len()))
+            .unwrap_or_else(|| (group.title.clone(), group.summary.clone()))
+    }
+
+    fn ai_workspace_source_signature_for_row(&self, row: &AiTimelineRow) -> u64 {
+        match &row.source {
+            AiTimelineRowSource::Group { group_id } => self
+                .ai_timeline_group(group_id.as_str())
+                .map(|group| self.ai_workspace_group_source_signature(row, group))
+                .unwrap_or_else(|| {
+                    ai_workspace_row_signature(
+                        self.ai_workspace_row_content_last_sequence(row),
+                        self.ai_workspace_row_is_expanded(row.id.as_str()),
+                    )
+                }),
+            _ => ai_workspace_row_signature(
+                self.ai_workspace_row_content_last_sequence(row),
+                self.ai_workspace_row_is_expanded(row.id.as_str()),
+            ),
+        }
+    }
+
+    fn ai_workspace_row_content_last_sequence(&self, row: &AiTimelineRow) -> u64 {
+        match &row.source {
+            AiTimelineRowSource::Item { item_key } => self
+                .ai_state_snapshot
+                .items
+                .get(item_key.as_str())
+                .map(|item| item.last_sequence)
+                .unwrap_or(row.last_sequence),
+            AiTimelineRowSource::TurnDiff { turn_key } => {
+                self.ai_workspace_turn_diff_last_sequence(turn_key.as_str(), row)
+            }
+            AiTimelineRowSource::TurnPlan { turn_key } => self
+                .ai_state_snapshot
+                .turn_plans
+                .get(turn_key.as_str())
+                .map(|plan| plan.last_sequence)
+                .unwrap_or(row.last_sequence),
+            AiTimelineRowSource::Group { .. } => row.last_sequence,
+        }
+    }
+
+    fn ai_workspace_turn_diff_last_sequence(&self, turn_key: &str, row: &AiTimelineRow) -> u64 {
+        self.ai_state_snapshot
+            .turn_diff_sequence(turn_key)
+            .unwrap_or(row.last_sequence)
     }
 }

--- a/crates/hunk-desktop/src/app/controller/core_bootstrap.rs
+++ b/crates/hunk-desktop/src/app/controller/core_bootstrap.rs
@@ -487,6 +487,8 @@ impl DiffViewer {
             ai_thread_sidebar_list_state: ListState::new(0, ListAlignment::Top, px(40.0)),
             ai_thread_sidebar_row_count: 0,
             ai_workspace_session: None,
+            ai_workspace_streaming_reveal_task: Task::ready(()),
+            ai_workspace_streaming_reveal_active: false,
             ai_workspace_surface_scroll_handle: ScrollHandle::default(),
             ai_workspace_surface_last_scroll_offset: None,
             ai_inline_review_surface: AiInlineReviewSurfaceState::new(),

--- a/crates/hunk-desktop/tests/ai_workspace_session.rs
+++ b/crates/hunk-desktop/tests/ai_workspace_session.rs
@@ -505,6 +505,42 @@ fn replace_source_row_smooths_preview_until_target_text_is_visible() {
 }
 
 #[test]
+fn reveal_steps_refresh_selection_surfaces_for_current_preview_text() {
+    let mut session = AiWorkspaceSession::new(
+        "thread-1",
+        source_rows(&[("row-1", 1)]),
+        single_blocks(vec![block("row-1", AiWorkspaceBlockKind::Message, "Hello")]),
+    );
+
+    let initial_surfaces = session.selection_surfaces_for_width(640);
+    assert_eq!(initial_surfaces[1].text, "Hello");
+
+    assert!(session.replace_source_row(
+        AiWorkspaceSourceRow {
+            row_id: "row-1".to_string(),
+            last_sequence: 2,
+        },
+        vec![block(
+            "row-1",
+            AiWorkspaceBlockKind::Message,
+            "Hello world!"
+        )],
+        true,
+    ));
+    assert!(session.reveal_pending_streaming_preview_step());
+
+    let updated_surfaces = session.selection_surfaces_for_width(640);
+    assert_ne!(updated_surfaces[1].text, "Hello");
+    assert_eq!(
+        updated_surfaces[1].text,
+        session
+            .block("row-1")
+            .expect("row-1 block should exist")
+            .preview
+    );
+}
+
+#[test]
 fn reveal_steps_update_cached_geometry_when_wrapping_changes() {
     let mut session = AiWorkspaceSession::new(
         "thread-1",

--- a/crates/hunk-desktop/tests/ai_workspace_session.rs
+++ b/crates/hunk-desktop/tests/ai_workspace_session.rs
@@ -99,12 +99,19 @@ fn source_rows(entries: &[(&str, u64)]) -> Arc<[AiWorkspaceSourceRow]> {
     )
 }
 
+fn single_blocks(blocks: Vec<AiWorkspaceBlock>) -> Vec<Vec<AiWorkspaceBlock>> {
+    blocks.into_iter().map(|block| vec![block]).collect()
+}
+
 #[test]
 fn session_matches_source_thread_and_row_ids() {
     let mut session = AiWorkspaceSession::new(
         "thread-1",
         source_rows(&[("row-1", 1), ("row-2", 2)]),
-        vec![block("row-1", AiWorkspaceBlockKind::Message, "preview")],
+        vec![
+            vec![block("row-1", AiWorkspaceBlockKind::Message, "preview")],
+            Vec::new(),
+        ],
     );
 
     assert_eq!(session.selection_scope_id(), "ai-workspace-thread:thread-1");
@@ -120,11 +127,11 @@ fn selection_surfaces_follow_rendered_message_text() {
     let mut session = AiWorkspaceSession::new(
         "thread-1",
         source_rows(&[("row-1", 1)]),
-        vec![block(
+        single_blocks(vec![block(
             "row-1",
             AiWorkspaceBlockKind::Message,
             "**bold** and `inline`",
-        )],
+        )]),
     );
 
     let selection_surfaces = session.selection_surfaces_for_width(640);
@@ -142,11 +149,11 @@ fn surface_snapshot_projects_visible_blocks_and_total_height() {
     let mut session = AiWorkspaceSession::new(
         "thread-1",
         source_rows(&[("row-1", 1), ("row-2", 2), ("row-3", 3)]),
-        vec![
+        single_blocks(vec![
             block("row-1", AiWorkspaceBlockKind::Message, "first preview"),
             block("row-2", AiWorkspaceBlockKind::DiffSummary, "diff preview"),
             block("row-3", AiWorkspaceBlockKind::Status, ""),
-        ],
+        ]),
     );
 
     let snapshot = session.surface_snapshot_with_stats(0, 220, 640).snapshot;
@@ -191,11 +198,11 @@ fn surface_snapshot_limits_visible_blocks_to_requested_range() {
     let mut session = AiWorkspaceSession::new(
         "thread-1",
         source_rows(&[("row-1", 1), ("row-2", 2), ("row-3", 3)]),
-        vec![
+        single_blocks(vec![
             block("row-1", AiWorkspaceBlockKind::Message, "first preview"),
             block("row-2", AiWorkspaceBlockKind::Message, "second preview"),
             block("row-3", AiWorkspaceBlockKind::Message, "third preview"),
-        ],
+        ]),
     );
 
     let snapshot = session.surface_snapshot_with_stats(96, 90, 640).snapshot;
@@ -220,7 +227,7 @@ fn surface_snapshot_supports_all_block_kinds_and_roles() {
             ("row-tool", 4),
             ("row-status", 5),
         ]),
-        vec![
+        single_blocks(vec![
             AiWorkspaceBlock {
                 id: "row-user".to_string(),
                 source_row_id: "row-user".to_string(),
@@ -247,7 +254,7 @@ fn surface_snapshot_supports_all_block_kinds_and_roles() {
             block("row-plan", AiWorkspaceBlockKind::Plan, "plan"),
             block("row-tool", AiWorkspaceBlockKind::Tool, "tool"),
             block("row-status", AiWorkspaceBlockKind::Status, "status"),
-        ],
+        ]),
     );
 
     let snapshot = session.surface_snapshot_with_stats(0, 640, 800).snapshot;
@@ -275,10 +282,10 @@ fn selection_matches_block_and_helpers_remain_addressable() {
     let mut session = AiWorkspaceSession::new(
         "thread-1",
         source_rows(&[("row-1", 1), ("row-2", 2)]),
-        vec![
+        single_blocks(vec![
             block("row-1", AiWorkspaceBlockKind::Message, "first preview"),
             block("row-2", AiWorkspaceBlockKind::DiffSummary, "diff preview"),
-        ],
+        ]),
     );
     let selection = AiWorkspaceSelection {
         block_id: "row-2".to_string(),
@@ -445,13 +452,99 @@ fn very_narrow_surface_widths_do_not_panic() {
         status_color_role: None,
         last_sequence: 1,
     };
-    let mut session =
-        AiWorkspaceSession::new("thread-1", source_rows(&[("row-narrow", 1)]), vec![block]);
+    let mut session = AiWorkspaceSession::new(
+        "thread-1",
+        source_rows(&[("row-narrow", 1)]),
+        single_blocks(vec![block]),
+    );
 
     let snapshot = session.surface_snapshot_with_stats(0, 200, 1).snapshot;
 
     assert_eq!(snapshot.viewport.visible_blocks.len(), 1);
     assert!(snapshot.viewport.total_surface_height_px > 0);
+}
+
+#[test]
+fn replace_source_row_smooths_preview_until_target_text_is_visible() {
+    let mut session = AiWorkspaceSession::new(
+        "thread-1",
+        source_rows(&[("row-1", 1)]),
+        single_blocks(vec![block("row-1", AiWorkspaceBlockKind::Message, "Hello")]),
+    );
+
+    assert!(session.replace_source_row(
+        AiWorkspaceSourceRow {
+            row_id: "row-1".to_string(),
+            last_sequence: 2,
+        },
+        vec![block(
+            "row-1",
+            AiWorkspaceBlockKind::Message,
+            "Hello world!"
+        )],
+        true,
+    ));
+    assert_eq!(
+        session.block("row-1").map(|block| block.preview.as_str()),
+        Some("Hello")
+    );
+    assert!(session.has_pending_streaming_preview());
+
+    for _ in 0..16 {
+        if !session.has_pending_streaming_preview() {
+            break;
+        }
+        assert!(session.reveal_pending_streaming_preview_step());
+    }
+
+    assert_eq!(
+        session.block("row-1").map(|block| block.preview.as_str()),
+        Some("Hello world!")
+    );
+    assert!(!session.has_pending_streaming_preview());
+}
+
+#[test]
+fn reveal_steps_update_cached_geometry_when_wrapping_changes() {
+    let mut session = AiWorkspaceSession::new(
+        "thread-1",
+        source_rows(&[("row-1", 1)]),
+        single_blocks(vec![block("row-1", AiWorkspaceBlockKind::Message, "short")]),
+    );
+
+    let initial_height = session
+        .surface_snapshot_with_stats(0, 240, 320)
+        .snapshot
+        .viewport
+        .total_surface_height_px;
+
+    assert!(session.replace_source_row(
+        AiWorkspaceSourceRow {
+            row_id: "row-1".to_string(),
+            last_sequence: 2,
+        },
+        vec![block(
+            "row-1",
+            AiWorkspaceBlockKind::Message,
+            "This is a much longer assistant preview that should wrap across multiple lines.",
+        )],
+        true,
+    ));
+
+    for _ in 0..24 {
+        if !session.has_pending_streaming_preview() {
+            break;
+        }
+        session.reveal_pending_streaming_preview_step();
+    }
+
+    let updated_height = session
+        .surface_snapshot_with_stats(0, 240, 320)
+        .snapshot
+        .viewport
+        .total_surface_height_px;
+
+    assert!(updated_height > initial_height);
 }
 
 #[test]

--- a/crates/hunk-desktop/tests/ai_workspace_session.rs
+++ b/crates/hunk-desktop/tests/ai_workspace_session.rs
@@ -527,9 +527,15 @@ fn reveal_steps_refresh_selection_surfaces_for_current_preview_text() {
         )],
         true,
     ));
-    assert!(session.reveal_pending_streaming_preview_step());
+    let mut updated_surfaces = initial_surfaces.clone();
+    for _ in 0..16 {
+        assert!(session.reveal_pending_streaming_preview_step());
+        updated_surfaces = session.selection_surfaces_for_width(640);
+        if updated_surfaces[1].text != "Hello" {
+            break;
+        }
+    }
 
-    let updated_surfaces = session.selection_surfaces_for_width(640);
     assert_ne!(updated_surfaces[1].text, "Hello");
     assert_eq!(
         updated_surfaces[1].text,


### PR DESCRIPTION
Preserve the current thread during transient streaming snapshots and reveal updated workspace previews incrementally so the UI stays stable while streamed content catches up.