### PR TITLE
[codex] Disable macOS and Linux Cargo cache

### DIFF
--- a/.github/workflows/adhoc-release-assets.yml
+++ b/.github/workflows/adhoc-release-assets.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           clean: false
 
-      - name: Cache cargo registry and Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: release-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       - name: Install cargo-packager
         run: nix develop --accept-flake-config -c cargo install cargo-packager --locked --version 0.11.8
@@ -126,14 +126,14 @@ jobs:
         with:
           clean: false
 
-      - name: Cache cargo registry and Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: release-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       - name: Resolve release version
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,14 +44,14 @@ jobs:
         with:
           clean: false
 
-      - name: Cache cargo registry and Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: pr-build-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: pr-build-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       # Temporarily disabled for PR builds; release packaging stays in release workflows.
       # - name: Resolve release version
@@ -171,15 +171,15 @@ jobs:
           use-cache: false
           version: 0.15.2
 
-      - name: Cache cargo registry and Rust dependencies
-        if: runner.os == 'macOS'
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: pr-build-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   if: runner.os == 'macOS'
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: pr-build-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       - name: Cache cargo registry and Rust dependencies
         if: runner.os != 'macOS'

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -43,14 +43,14 @@ jobs:
         with:
           clean: false
 
-      - name: Cache cargo registry and Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: release-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       - name: Install cargo-packager
         run: nix develop --accept-flake-config -c cargo install cargo-packager --locked --version 0.11.8
@@ -154,14 +154,14 @@ jobs:
         with:
           clean: false
 
-      - name: Cache cargo registry and Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: release-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       - name: Resolve release version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,14 @@ jobs:
         with:
           clean: false
 
-      - name: Cache cargo registry and Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: release-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       - name: Install cargo-packager
         run: nix develop --accept-flake-config -c cargo install cargo-packager --locked --version 0.11.8
@@ -146,14 +146,14 @@ jobs:
         with:
           clean: false
 
-      - name: Cache cargo registry and Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ runner.os }}-desktop-v2
-          workspaces: |
-            . -> target
-          cache-on-failure: "true"
-          cmd-format: nix develop --accept-flake-config -c {0}
+      # - name: Cache cargo registry and Rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: release-${{ runner.os }}-desktop-v2
+      #     workspaces: |
+      #       . -> target
+      #     cache-on-failure: "true"
+      #     cmd-format: nix develop --accept-flake-config -c {0}
 
       - name: Resolve release version
         run: |


### PR DESCRIPTION
## Summary
- comment out macOS Cargo cache steps in PR and release workflows
- comment out Linux Cargo cache steps in PR and release workflows
- preserve the current master Linux flow: `ubuntu-self-hosted` runners with `nix develop` commands

## Validation
- `git diff --check`
- parsed touched workflow YAML with Ruby